### PR TITLE
chore: add uv.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ build/
 *.egg-info/
 *.egg
 
+# uv (library project - no lock file)
+uv.lock
+
 # Virtual environments
 .venv/
 venv/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,10 @@ source .venv/bin/activate
 pip install -e ".[dev]"
 ```
 
+> **Note:** We use `uv pip install` instead of `uv sync` because this is a **library project**.
+> We don't commit `uv.lock` to maintain dependency flexibility for downstream users.
+> See [Project Management](#project-management) for more details.
+
 ### Running Tests
 
 ```bash


### PR DESCRIPTION
## Summary

Add `uv.lock` to `.gitignore` with documentation explaining why library projects should not commit lock files.

## Changes

- Added `uv.lock` to `.gitignore` with explanatory comment
- Documented the rationale in CONTRIBUTING.md Development Setup section

## Rationale

Library projects should not commit lock files (`uv.lock`) to maintain dependency flexibility for downstream users. This ensures:
- Users can resolve dependencies based on their own project's constraints
- Avoids forcing specific transitive dependency versions on consumers
- Maintains compatibility across different environments

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)