### PR TITLE
ci: add Python 3.14 and Wagtail 7.2 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         django-version: ["4.2", "5.1", "5.2"]
-        wagtail-version: ["5.2", "6.4", "7.0"]
+        wagtail-version: ["5.2", "6.4", "7.0", "7.2"]
         exclude:
           # Django 5.2 requires Python 3.11+
           - python-version: "3.10"
@@ -29,6 +29,18 @@ jobs:
             wagtail-version: "5.2"
           - django-version: "5.2"
             wagtail-version: "5.2"
+          # Python 3.14 only supported by Django 5.2
+          - python-version: "3.14"
+            django-version: "4.2"
+          - python-version: "3.14"
+            django-version: "5.1"
+          # Python 3.14 only supported by Wagtail 7.2
+          - python-version: "3.14"
+            wagtail-version: "5.2"
+          - python-version: "3.14"
+            wagtail-version: "6.4"
+          - python-version: "3.14"
+            wagtail-version: "7.0"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Expand CI test matrix to include the latest stable releases of Python and Wagtail.

## Changes

### Added Versions
- **Python 3.14** (released October 7, 2025)
- **Wagtail 7.2** (released November 5, 2025)

### Compatibility Matrix

**New combinations:**
- Python 3.14 + Django 5.2 + Wagtail 7.2
- Wagtail 7.2 with all Python versions (3.10-3.14) and all Django versions (4.2, 5.1, 5.2)

**Exclusions added:**
- Python 3.14 + Django 4.2 (not supported)
- Python 3.14 + Django 5.1 (not supported)
- Python 3.14 + Wagtail 5.2/6.4/7.0 (not supported)

### Test Matrix Size
- **Before:** 26 combinations
- **After:** 39 combinations

## Compatibility Research

### Python 3.14 Support
- ✅ **Django 5.2**: Officially supported
- ❌ **Django 5.1**: Not supported
- ❌ **Django 4.2**: Not supported

### Wagtail 7.2 Support
- **Python versions:** 3.10, 3.11, 3.12, 3.13, 3.14
- **Django versions:** 4.2, 5.1, 5.2
- Note: Wagtail 7.2 dropped support for Python 3.8 and 3.9

## References

- [Django 5.2 Installation FAQ](https://docs.djangoproject.com/en/5.2/faq/install/)
- [Which versions of Django will support Python 3.14](https://forum.djangoproject.com/t/which-versions-of-django-will-support-python-3-14/43005)
- [Wagtail 7.2 Release Notes](https://docs.wagtail.org/en/stable/releases/7.2.html)
- [Wagtail Upgrading Documentation](https://docs.wagtail.org/en/stable/releases/upgrading.html)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)