### PR TITLE
docs: add comprehensive development guide with version compatibility matrix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,111 @@ This matches the CI matrix exactly, allowing you to verify compatibility before 
 
 **Note:** Tox will create virtual environments for each combination. The first run will be slow, but subsequent runs are faster due to caching.
 
+## Supported Versions
+
+### Python Versions
+- **3.10** (minimum)
+- **3.11**
+- **3.12**
+- **3.13**
+- **3.14** (latest)
+
+### Django Versions
+- **4.2** (LTS - Long Term Support until April 2026)
+- **5.1**
+- **5.2** (LTS - Long Term Support until April 2028)
+
+### Wagtail Versions
+- **5.2** (LTS - Long Term Support)
+- **6.4**
+- **7.0** (LTS - Long Term Support)
+- **7.2** (latest)
+
+## Version Compatibility Matrix
+
+Our CI tests 39 valid combinations of Python, Django, and Wagtail versions.
+
+### Compatibility Table
+
+| Python | Django 4.2 | Django 5.1 | Django 5.2 |
+|--------|------------|------------|------------|
+| **Wagtail 5.2** ||||
+| 3.10 | ✅ | ❌ | ❌ |
+| 3.11 | ✅ | ❌ | ❌ |
+| 3.12 | ✅ | ❌ | ❌ |
+| 3.13 | ✅ | ❌ | ❌ |
+| 3.14 | ❌ | ❌ | ❌ |
+| **Wagtail 6.4** ||||
+| 3.10 | ✅ | ✅ | ❌ |
+| 3.11 | ✅ | ✅ | ✅ |
+| 3.12 | ✅ | ✅ | ✅ |
+| 3.13 | ✅ | ✅ | ✅ |
+| 3.14 | ❌ | ❌ | ❌ |
+| **Wagtail 7.0** ||||
+| 3.10 | ✅ | ✅ | ❌ |
+| 3.11 | ✅ | ✅ | ✅ |
+| 3.12 | ✅ | ✅ | ✅ |
+| 3.13 | ✅ | ✅ | ✅ |
+| 3.14 | ❌ | ❌ | ❌ |
+| **Wagtail 7.2** ||||
+| 3.10 | ✅ | ✅ | ❌ |
+| 3.11 | ✅ | ✅ | ✅ |
+| 3.12 | ✅ | ✅ | ✅ |
+| 3.13 | ✅ | ✅ | ✅ |
+| 3.14 | ❌ | ❌ | ✅ |
+
+**Summary:**
+- **Total combinations**: 60 (5 Python × 3 Django × 4 Wagtail)
+- **Valid combinations**: 39 (tested in CI)
+- **Excluded combinations**: 21
+
+### Exclusion Rationale
+
+Certain combinations are excluded due to compatibility constraints:
+
+1. **Python 3.10 + Django 5.2**: Django 5.2 requires Python 3.11+
+2. **Wagtail 5.2 + Django 5.1/5.2**: Wagtail 5.2 only supports Django up to 4.2
+3. **Python 3.14 + Django 4.2/5.1**: Python 3.14 is only supported by Django 5.2+
+4. **Python 3.14 + Wagtail 5.2/6.4/7.0**: Python 3.14 is only supported by Wagtail 7.2+
+
+These exclusions are based on official compatibility tables:
+- [Django FAQ: Installation](https://docs.djangoproject.com/en/stable/faq/install/)
+- [Wagtail Upgrading Guide](https://docs.wagtail.org/en/stable/releases/upgrading.html)
+
+## Test Matrix Strategy
+
+### CI Workflow
+Our GitHub Actions CI tests all 39 valid combinations in parallel, ensuring compatibility across:
+- All supported Python versions
+- All supported Django versions
+- All supported Wagtail versions
+
+See `.github/workflows/ci.yml` for the complete matrix configuration.
+
+### Local Testing with tox
+Use `tox` to replicate the CI matrix locally before pushing:
+
+```bash
+# Test all 39 combinations
+tox
+
+# Test specific Python version
+tox -e py314
+
+# Test specific combination
+tox -e py314-django52-wagtail72
+```
+
+### Why No `uv.lock`?
+
+This is a **library project**, not an application. We intentionally don't commit `uv.lock` to:
+
+- Allow downstream users to resolve dependencies based on their own constraints
+- Maintain maximum compatibility across different environments
+- Avoid forcing specific transitive dependency versions
+
+Applications should use lock files for reproducible builds. Libraries should not.
+
 ### Code Style
 
 ```bash


### PR DESCRIPTION
## Summary

Add comprehensive development documentation to `CONTRIBUTING.md` covering supported versions, compatibility matrix, test strategy, and dependency management.

## Changes

### Supported Versions Section
Documents all supported versions with LTS indicators:
- **Python**: 3.10, 3.11, 3.12, 3.13, 3.14
- **Django**: 4.2 (LTS), 5.1, 5.2 (LTS)
- **Wagtail**: 5.2 (LTS), 6.4, 7.0 (LTS), 7.2

### Version Compatibility Matrix
Complete table showing 39 valid combinations:
- Visual guide with ✅ (supported) and ❌ (excluded)
- Organized by Wagtail version for easy reference
- Summary: 60 total - 21 excluded = 39 valid

### Exclusion Rationale
Clear explanation of why certain combinations are excluded:
1. Python 3.10 + Django 5.2 (Django 5.2 requires Python 3.11+)
2. Wagtail 5.2 + Django 5.1/5.2 (Wagtail 5.2 only supports Django 4.2)
3. Python 3.14 + Django 4.2/5.1 (Python 3.14 requires Django 5.2+)
4. Python 3.14 + Wagtail 5.2/6.4/7.0 (Python 3.14 requires Wagtail 7.2+)

Includes references to official documentation:
- Django FAQ: Installation
- Wagtail Upgrading Guide

### Test Matrix Strategy
Explains our testing approach:
- **CI Workflow**: 39 combinations tested in parallel
- **Local Testing**: How to use tox to replicate CI
- **Reference**: Points to `.github/workflows/ci.yml`

### Why No `uv.lock`?
Explains library vs application dependency management:
- Libraries should NOT commit lock files
- Allows downstream users flexibility
- Maintains maximum compatibility
- Avoids forcing specific transitive dependency versions

## Benefits for Contributors

✅ Clear understanding of which versions are supported
✅ Visual compatibility matrix for quick reference
✅ Rationale for exclusions with official sources
✅ Instructions for local testing with tox
✅ Understanding of library dependency philosophy

## References

- Issue #10: Test environment setup
- Issue #24: Python 3.14 and Wagtail 7.2 addition
- Issue #28: tox for local matrix testing
- [Django FAQ: Installation](https://docs.djangoproject.com/en/stable/faq/install/)
- [Wagtail Upgrading Guide](https://docs.wagtail.org/en/stable/releases/upgrading.html)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)