### PR TITLE
docs: Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # wagtail-reusable-blocks
 
 [![PyPI version](https://badge.fury.io/py/wagtail-reusable-blocks.svg)](https://badge.fury.io/py/wagtail-reusable-blocks)
+[![CI](https://github.com/kkm-horikawa/wagtail-reusable-blocks/actions/workflows/ci.yml/badge.svg)](https://github.com/kkm-horikawa/wagtail-reusable-blocks/actions/workflows/ci.yml)
 [![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 A Wagtail CMS extension for creating **reusable content blocks** with an advanced **slot-based templating system**.


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow badge to README
- Position between PyPI version and License badges
- Badge shows current build status and links to workflow runs

## Changes

- Added CI badge using GitHub Actions badge format
- Badge URL: `https://github.com/kkm-horikawa/wagtail-reusable-blocks/actions/workflows/ci.yml/badge.svg`
- Links to workflow runs page for easy access to CI results

## Visual Preview

The badges now appear in this order:
1. PyPI version
2. **CI status** (new)
3. License

## Closes

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)