### PR TITLE
feat: Implement template rendering system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,20 @@ version_scheme = "no-guess-dev"
 [tool.hatch.build.targets.wheel]
 packages = ["src/wagtail_reusable_blocks"]
 
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src",
+    "/tests",
+    "/README.md",
+    "/LICENSE",
+]
+
+[tool.hatch.build]
+include = [
+    "src/wagtail_reusable_blocks/**/*.py",
+    "src/wagtail_reusable_blocks/templates/**/*.html",
+]
+
 [tool.ruff]
 line-length = 88
 target-version = "py310"

--- a/src/wagtail_reusable_blocks/templates/wagtail_reusable_blocks/reusable_block.html
+++ b/src/wagtail_reusable_blocks/templates/wagtail_reusable_blocks/reusable_block.html
@@ -1,0 +1,2 @@
+{% load wagtailcore_tags %}
+{% include_block block.content %}

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,215 @@
+"""Tests for template rendering system."""
+
+import pytest
+from django.template import TemplateDoesNotExist
+from django.test import override_settings
+
+from wagtail_reusable_blocks.models import ReusableBlock
+
+
+class TestTemplateRendering:
+    """Tests for ReusableBlock.render() method."""
+
+    @pytest.fixture
+    def block(self, db):
+        """Create a test ReusableBlock."""
+        return ReusableBlock.objects.create(
+            name="Test Block",
+            content=[
+                ("rich_text", "<p>Hello World</p>"),
+            ],
+        )
+
+    def test_render_with_default_template(self, block):
+        """render() uses default template."""
+        html = block.render()
+
+        # Default template simply renders the content
+        assert "<p>Hello World</p>" in html
+
+    def test_render_with_custom_template_via_settings(self, block, tmp_path, settings):
+        """render() uses custom template from settings."""
+        # Create custom template
+        template_dir = tmp_path / "templates"
+        template_dir.mkdir()
+        custom_template = template_dir / "custom_block.html"
+        custom_template.write_text(
+            "{% load wagtailcore_tags %}"
+            '<div class="custom">{% include_block block.content %}</div>'
+        )
+
+        # Configure settings
+        templates = settings.TEMPLATES.copy()
+        templates[0] = templates[0].copy()
+        templates[0]["DIRS"] = [str(template_dir)]
+
+        with override_settings(
+            TEMPLATES=templates,
+            WAGTAIL_REUSABLE_BLOCKS={"TEMPLATE": "custom_block.html"},
+        ):
+            html = block.render()
+
+        assert '<div class="custom">' in html
+        assert "<p>Hello World</p>" in html
+
+    def test_render_with_custom_template_via_parameter(self, block, tmp_path, settings):
+        """render() uses custom template from parameter."""
+        # Create custom template
+        template_dir = tmp_path / "templates"
+        template_dir.mkdir()
+        custom_template = template_dir / "param_template.html"
+        custom_template.write_text(
+            "{% load wagtailcore_tags %}"
+            '<div class="param-override">{% include_block block.content %}</div>'
+        )
+
+        # Configure settings
+        templates = settings.TEMPLATES.copy()
+        templates[0] = templates[0].copy()
+        templates[0]["DIRS"] = [str(template_dir)]
+
+        with override_settings(TEMPLATES=templates):
+            html = block.render(template="param_template.html")
+
+        assert '<div class="param-override">' in html
+        assert "<p>Hello World</p>" in html
+
+    def test_render_with_context_passing(self, block, tmp_path, settings):
+        """render() passes context to template."""
+        # Create custom template that uses context
+        template_dir = tmp_path / "templates"
+        template_dir.mkdir()
+        custom_template = template_dir / "context_template.html"
+        custom_template.write_text(
+            "{% load wagtailcore_tags %}"
+            '<div data-page="{{ page_title }}">'
+            "{% include_block block.content %}"
+            "</div>"
+        )
+
+        # Configure settings
+        templates = settings.TEMPLATES.copy()
+        templates[0] = templates[0].copy()
+        templates[0]["DIRS"] = [str(template_dir)]
+
+        with override_settings(TEMPLATES=templates):
+            html = block.render(
+                context={"page_title": "My Page"}, template="context_template.html"
+            )
+
+        assert 'data-page="My Page"' in html
+
+    def test_render_with_empty_content(self, db):
+        """render() handles empty content gracefully."""
+        block = ReusableBlock.objects.create(
+            name="Empty Block",
+            content=[],
+        )
+
+        html = block.render()
+
+        # Empty content renders as empty string (just whitespace from template)
+        assert html.strip() == ""
+
+    def test_render_template_does_not_exist(self, block):
+        """render() raises TemplateDoesNotExist for missing template."""
+        with pytest.raises(
+            TemplateDoesNotExist, match="Template 'nonexistent/template.html' not found"
+        ):
+            block.render(template="nonexistent/template.html")
+
+    def test_render_helpful_error_message_for_custom_template(self, block):
+        """render() provides helpful error message for custom template."""
+        with pytest.raises(
+            TemplateDoesNotExist,
+            match="Make sure it exists in one of your TEMPLATES\\['DIRS'\\]",
+        ):
+            block.render(template="custom/missing.html")
+
+    def test_render_parameter_precedence(self, block, tmp_path, settings):
+        """Template parameter takes precedence over settings."""
+        # Create both templates
+        template_dir = tmp_path / "templates"
+        template_dir.mkdir()
+
+        settings_template = template_dir / "settings_template.html"
+        settings_template.write_text(
+            "{% load wagtailcore_tags %}"
+            '<div class="from-settings">{% include_block block.content %}</div>'
+        )
+
+        param_template = template_dir / "param_template.html"
+        param_template.write_text(
+            "{% load wagtailcore_tags %}"
+            '<div class="from-param">{% include_block block.content %}</div>'
+        )
+
+        # Configure settings
+        templates = settings.TEMPLATES.copy()
+        templates[0] = templates[0].copy()
+        templates[0]["DIRS"] = [str(template_dir)]
+
+        with override_settings(
+            TEMPLATES=templates,
+            WAGTAIL_REUSABLE_BLOCKS={"TEMPLATE": "settings_template.html"},
+        ):
+            # Parameter should override settings
+            html = block.render(template="param_template.html")
+
+        assert '<div class="from-param">' in html
+        assert '<div class="from-settings">' not in html
+
+
+class TestTemplateContextVariables:
+    """Tests for template context variables."""
+
+    @pytest.fixture
+    def block(self, db):
+        """Create a test ReusableBlock."""
+        return ReusableBlock.objects.create(
+            name="Context Test",
+            content=[("rich_text", "<p>Content</p>")],
+        )
+
+    def test_block_variable_in_context(self, block, tmp_path, settings):
+        """Template receives 'block' variable."""
+        # Create custom template that uses block variable
+        template_dir = tmp_path / "templates"
+        template_dir.mkdir()
+        custom_template = template_dir / "block_var_template.html"
+        custom_template.write_text(
+            "{% load wagtailcore_tags %}"
+            '<div data-slug="{{ block.slug }}">{% include_block block.content %}</div>'
+        )
+
+        # Configure settings
+        templates = settings.TEMPLATES.copy()
+        templates[0] = templates[0].copy()
+        templates[0]["DIRS"] = [str(template_dir)]
+
+        with override_settings(TEMPLATES=templates):
+            html = block.render(template="block_var_template.html")
+
+        assert 'data-slug="context-test"' in html
+
+    def test_custom_context_merged(self, block, tmp_path, settings):
+        """Custom context is merged with default context."""
+        # Create custom template that uses both custom and block context
+        template_dir = tmp_path / "templates"
+        template_dir.mkdir()
+        custom_template = template_dir / "merged_context.html"
+        custom_template.write_text(
+            "{% load wagtailcore_tags %}<div>{{ custom_var }}|{{ block.name }}</div>"
+        )
+
+        # Configure settings
+        templates = settings.TEMPLATES.copy()
+        templates[0] = templates[0].copy()
+        templates[0]["DIRS"] = [str(template_dir)]
+
+        with override_settings(TEMPLATES=templates):
+            html = block.render(
+                context={"custom_var": "test"}, template="merged_context.html"
+            )
+
+        assert "test|Context Test" in html


### PR DESCRIPTION
## Summary

Implements the template rendering system for ReusableBlock with flexible override options and comprehensive error handling.

## Key Features

✅ **Minimal Default Template**
- Simple `{% include_block block.content %}` - no unnecessary wrappers
- Users can add custom markup via template override

✅ **Flexible Template Override**
- Via settings: `WAGTAIL_REUSABLE_BLOCKS['TEMPLATE']`
- Via parameter: `block.render(template='custom.html')`
- Clear precedence: parameter > settings > default

✅ **Context Passing**
- Accepts both `dict` and Django `Context` objects
- Merges custom context with default `block` variable
- Parent template context accessible

✅ **User-Friendly Error Handling**
- Custom template missing: "Make sure it exists in TEMPLATES['DIRS']..."
- Default template missing: "Try reinstalling or set custom template..."
- Clear troubleshooting guidance

✅ **Verified Package Build**
- Templates correctly included in wheel distribution
- Tested with actual build: `unzip -l *.whl | grep templates`

## Implementation

### ReusableBlock.render() Method
```python
def render(
    self,
    context: "dict[str, Any] | Context | None" = None,
    template: str | None = None,
) -> SafeString:
    """Render the reusable block using a template."""
```

### Default Template
```html
{% load wagtailcore_tags %}
{% include_block block.content %}
```

### Package Configuration
```toml
[tool.hatch.build]
include = [
    "src/wagtail_reusable_blocks/**/*.py",
    "src/wagtail_reusable_blocks/templates/**/*.html",
]
```

## Usage Examples

### Basic Usage
```python
block = ReusableBlock.objects.get(slug='header')
html = block.render()
```

### Custom Context
```python
html = block.render(context={'page': page, 'user': request.user})
```

### Custom Template
```python
# Via settings
WAGTAIL_REUSABLE_BLOCKS = {
    'TEMPLATE': 'myapp/custom_block.html',
}

# Via parameter (takes precedence)
html = block.render(template='myapp/special_block.html')
```

## Tests

**10 new tests** covering:
- Default template rendering
- Settings override
- Parameter override  
- Context passing (dict and Context)
- Empty content handling
- Template precedence
- Error messages
- Block variable in context

**All 40 tests passing** ✅

## Quality Checks

- ✅ Lint: ruff check passed
- ✅ Format: ruff format passed  
- ✅ Type check: mypy strict mode passed
- ✅ All 40 tests passing
- ✅ Package build verified

## Closes

Closes #13

---

