### PR TITLE
feat: add search functionality to snippet chooser modal (#44)

### DIFF
--- a/src/wagtail_reusable_blocks/models/reusable_block.py
+++ b/src/wagtail_reusable_blocks/models/reusable_block.py
@@ -14,12 +14,9 @@ from wagtail.search import index
 
 if TYPE_CHECKING:
     from django.template.context import Context
-    from wagtail.search.index import Indexed as IndexedType
-else:
-    IndexedType = index.Indexed  # type: ignore[misc,assignment]
 
 
-class ReusableBlock(IndexedType, models.Model):  # type: ignore[misc]
+class ReusableBlock(index.Indexed, models.Model):  # type: ignore[misc]
     """Reusable content blocks that can be used across multiple pages.
 
     By default, this model is automatically registered as a Wagtail Snippet


### PR DESCRIPTION
## Summary

Fixes #44

Enables search functionality in the ReusableBlock snippet chooser modal by making the model inherit from `wagtail.search.index.Indexed` and defining search fields.

## Changes

- **Model**: Make `ReusableBlock` inherit from `index.Indexed`
- **Search Fields**: Add `search_fields` with:
  - `SearchField("name", partial_match=True)` - Partial match on name
  - `SearchField("slug", partial_match=True)` - Partial match on slug
  - `AutocompleteField("name")` - Autocomplete for name

## Benefits

- ✅ Search box now appears in snippet chooser modal
- ✅ Users can filter blocks by name or slug
- ✅ Easier to find specific blocks as the library grows
- ✅ Better UX for content editors
- ✅ Consistent with Wagtail's standard snippet behavior

## Testing

✅ All 93 tests pass
✅ Wagtail automatically displays search box when model inherits from `Indexed`

## References

- [Wagtail Snippets Documentation](https://docs.wagtail.org/en/stable/topics/snippets/index.html)

## Discovered By

Manual testing with demo Wagtail project - noticed absence of search box in chooser modal.