### PR TITLE
docs: add Django Packages badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # wagtail-reusable-blocks
 
 [![PyPI version](https://badge.fury.io/py/wagtail-reusable-blocks.svg)](https://badge.fury.io/py/wagtail-reusable-blocks)
+[![Published on Django Packages](https://img.shields.io/badge/Published%20on-Django%20Packages-0c3c26)](https://djangopackages.org/packages/p/wagtail-reusable-blocks/)
 [![CI](https://github.com/kkm-horikawa/wagtail-reusable-blocks/actions/workflows/ci.yml/badge.svg)](https://github.com/kkm-horikawa/wagtail-reusable-blocks/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/kkm-horikawa/wagtail-reusable-blocks/branch/develop/graph/badge.svg)](https://codecov.io/gh/kkm-horikawa/wagtail-reusable-blocks)
 [![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)


### PR DESCRIPTION
## Changes

Added a Django Packages badge to the README to increase project visibility.

### Why?

- Shows the package is officially registered on [Django Packages](https://djangopackages.org/packages/p/wagtail-reusable-blocks/)
- Automatically makes it visible on [wagtail.org/packages](https://wagtail.org/packages/)
- Increases credibility in the Wagtail community
- Follows common practice for Wagtail packages

### Badge Details

- Color:  (Django Packages green)
- Links to: https://djangopackages.org/packages/p/wagtail-reusable-blocks/
- Position: After PyPI badge, before CI badge

## Preview

The badge appears in the README header alongside other status badges.