### PR TITLE
fix: update release drafter to track PRs merged to develop

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request_target:
     types: [opened, reopened, synchronize]
 
@@ -18,5 +19,7 @@ jobs:
       - uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
+          # Track PRs merged to develop branch for the draft
+          commitish: develop
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add develop branch to workflow triggers
- Set commitish to develop so PRs merged to develop are recorded in release draft

Previously, only PRs merged to main were tracked, but our workflow merges PRs to develop first, then releases to main. This change ensures all PRs merged to develop are properly recorded in the release draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)