### PR TITLE
ci: add TestPyPI deployment for develop branch

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,0 +1,45 @@
+name: Publish Dev to TestPyPI
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build package
+        run: uv build
+
+      - name: Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi-dev
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true


### PR DESCRIPTION
## Summary

- Add new GitHub Actions workflow `publish-dev.yml`
- Automatically deploy to TestPyPI on push to `develop` branch
- Use Trusted Publishing for secure authentication

## Setup Required (Manual Steps)

After merging this PR:

1. **Create GitHub Environment**:
   - Go to Repository Settings → Environments
   - Create new environment: `testpypi-dev`

2. **Configure Trusted Publisher on TestPyPI**:
   - Go to https://test.pypi.org/manage/account/publishing/
   - Add a new pending publisher (or update existing):
     - PyPI Project Name: `wagtail-reusable-blocks`
     - Owner: `kkm-horikawa`
     - Repository: `wagtail-reusable-blocks`
     - Workflow name: `publish-dev.yml`
     - Environment name: `testpypi-dev`

## Installation from TestPyPI

```bash
pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ wagtail-reusable-blocks
```

## Test Plan

- [x] Workflow file syntax is valid
- [ ] After merge: verify deployment triggers on develop push
- [ ] After setup: verify package available on TestPyPI

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)