### PR TITLE
Release v0.4.1

### DIFF
--- a/src/wagtail_reusable_blocks/templates/wagtail_reusable_blocks/blocks/image.html
+++ b/src/wagtail_reusable_blocks/templates/wagtail_reusable_blocks/blocks/image.html
@@ -1,2 +1,2 @@
 {% load wagtailimages_tags %}
-{% picture value.image original format-{avif,webp,jpeg} preserve-svg alt=value.image.title loading="lazy" decoding="async" %}
+{% picture value.image original format-{avif,webp,jpeg} preserve-svg alt=value.image.title loading="lazy" decoding="async" style="max-width: 100%; height: auto;" %}


### PR DESCRIPTION
## Summary

Patch release v0.4.1 with bug fix for ImageBlock.

### Bug Fixes
- **ImageBlock overflow fix**: Added `max-width: 100%; height: auto;` inline style to prevent images from overflowing their container (#93)

## Test Plan
- [ ] Verify ImageBlock images stay within container bounds
- [ ] Check responsive behavior on different screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)