### PR TITLE
feat: mark Python strings for translation (i18n)

### DIFF
--- a/src/wagtail_reusable_blocks/apps.py
+++ b/src/wagtail_reusable_blocks/apps.py
@@ -4,6 +4,7 @@ import logging
 
 from django.apps import AppConfig
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.translation import gettext_lazy as _
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +14,7 @@ class WagtailReusableBlocksConfig(AppConfig):
 
     default_auto_field = "django.db.models.BigAutoField"
     name = "wagtail_reusable_blocks"
-    verbose_name = "Wagtail Reusable Blocks"
+    verbose_name = _("Wagtail Reusable Blocks")
 
     def ready(self) -> None:
         """

--- a/src/wagtail_reusable_blocks/blocks/chooser.py
+++ b/src/wagtail_reusable_blocks/blocks/chooser.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING, Any
 
 from django.utils.safestring import SafeString
+from django.utils.translation import gettext_lazy as _
 from wagtail.snippets.blocks import SnippetChooserBlock
 
 from ..models import ReusableBlock
@@ -103,8 +104,8 @@ class ReusableBlockChooserBlock(SnippetChooserBlockType):  # type: ignore[misc]
             )
             return (
                 '<div class="reusable-block-max-depth-warning">'
-                "Maximum nesting depth exceeded"
-                "</div>"
+                + str(_("Maximum nesting depth exceeded"))
+                + "</div>"
             )
 
         try:

--- a/src/wagtail_reusable_blocks/blocks/head_injection.py
+++ b/src/wagtail_reusable_blocks/blocks/head_injection.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from django.utils.translation import gettext_lazy as _
 from wagtail.blocks import TextBlock
 
 
@@ -65,4 +66,4 @@ class HeadInjectionBlock(TextBlock):  # type: ignore[misc]
 
     class Meta:
         icon = "code"
-        label = "Preview Head Injection"
+        label = _("Preview Head Injection")

--- a/src/wagtail_reusable_blocks/blocks/image.py
+++ b/src/wagtail_reusable_blocks/blocks/image.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING
 
+from django.utils.translation import gettext_lazy as _
 from wagtail.blocks import StructBlock
 from wagtail.images.blocks import ImageChooserBlock
 
@@ -33,12 +34,12 @@ class ImageBlock(StructBlockType):  # type: ignore[misc]
 
     image = ImageChooserBlock(
         required=True,
-        label="Image",
-        help_text="Select an image to display",
+        label=_("Image"),
+        help_text=_("Select an image to display"),
     )
 
     class Meta:
         template = "wagtail_reusable_blocks/blocks/image.html"
         icon = "image"
-        label = "Image"
-        help_text = "Image with responsive format support"
+        label = _("Image")
+        help_text = _("Image with responsive format support")

--- a/src/wagtail_reusable_blocks/blocks/layout.py
+++ b/src/wagtail_reusable_blocks/blocks/layout.py
@@ -4,6 +4,7 @@ import warnings
 from typing import TYPE_CHECKING
 
 from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy as _
 from wagtail.blocks import StreamBlock, StructBlock
 from wagtail.snippets.blocks import SnippetChooserBlock
 
@@ -69,7 +70,7 @@ class ReusableLayoutBlock(StructBlockType):  # type: ignore[misc]
 
     layout = SnippetChooserBlock(
         target_model="wagtail_reusable_blocks.ReusableBlock",
-        help_text="Select a layout template with slot placeholders",
+        help_text=_("Select a layout template with slot placeholders"),
     )
 
     def __init__(self, local_blocks=None, **kwargs):  # type: ignore[no-untyped-def]
@@ -87,7 +88,7 @@ class ReusableLayoutBlock(StructBlockType):  # type: ignore[misc]
                             ("slot_fill", SlotFillBlock()),  # type: ignore[no-untyped-call]
                         ],
                         required=False,
-                        help_text="Fill the slots in this layout template",
+                        help_text=_("Fill the slots in this layout template"),
                     ),
                 )
             ]
@@ -96,8 +97,8 @@ class ReusableLayoutBlock(StructBlockType):  # type: ignore[misc]
 
     class Meta:
         icon = "doc-empty"
-        label = "Reusable Layout"
-        help_text = "Layout template with customizable content slots"
+        label = _("Reusable Layout")
+        help_text = _("Layout template with customizable content slots")
         adapter_class = ReusableLayoutBlockAdapter
 
     def render(self, value, context=None):  # type: ignore[no-untyped-def]

--- a/src/wagtail_reusable_blocks/blocks/slot_fill.py
+++ b/src/wagtail_reusable_blocks/blocks/slot_fill.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING
 
+from django.utils.translation import gettext_lazy as _
 from wagtail.blocks import (
     CharBlock,
     RawHTMLBlock,
@@ -92,8 +93,8 @@ class SlotFillBlock(StructBlockType):  # type: ignore[misc]
 
     slot_id = CharBlock(
         max_length=50,
-        help_text="The slot identifier to fill (e.g., 'main', 'sidebar')",
-        label="Slot ID",
+        help_text=_("The slot identifier to fill (e.g., 'main', 'sidebar')"),
+        label=_("Slot ID"),
     )
 
     def __init__(self, local_blocks=None, **kwargs):  # type: ignore[no-untyped-def]
@@ -109,8 +110,8 @@ class SlotFillBlock(StructBlockType):  # type: ignore[misc]
                 (
                     "content",
                     SlotContentStreamBlock(  # type: ignore[no-untyped-call]
-                        help_text="Content to inject into this slot",
-                        label="Slot Content",
+                        help_text=_("Content to inject into this slot"),
+                        label=_("Slot Content"),
                     ),
                 )
             ]
@@ -119,8 +120,8 @@ class SlotFillBlock(StructBlockType):  # type: ignore[misc]
 
     class Meta:
         icon = "placeholder"
-        label = "Slot Fill"
-        help_text = "Fill a specific slot with content"
+        label = _("Slot Fill")
+        help_text = _("Fill a specific slot with content")
 
 
 # Nesting support (Issue #49):

--- a/src/wagtail_reusable_blocks/locale/en/LC_MESSAGES/django.po
+++ b/src/wagtail_reusable_blocks/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wagtail-reusable-blocks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-08 00:00+0000\n"
+"POT-Creation-Date: 2025-12-08 20:16+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -15,3 +15,126 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:17
+msgid "Wagtail Reusable Blocks"
+msgstr ""
+
+#: blocks/chooser.py:107 models/reusable_block.py:89
+msgid "Maximum nesting depth exceeded"
+msgstr ""
+
+#: blocks/head_injection.py:69 models/reusable_block.py:46
+msgid "Preview Head Injection"
+msgstr ""
+
+#: blocks/image.py:37 blocks/image.py:44
+msgid "Image"
+msgstr ""
+
+#: blocks/image.py:38
+msgid "Select an image to display"
+msgstr ""
+
+#: blocks/image.py:45
+msgid "Image with responsive format support"
+msgstr ""
+
+#: blocks/layout.py:73
+msgid "Select a layout template with slot placeholders"
+msgstr ""
+
+#: blocks/layout.py:91
+msgid "Fill the slots in this layout template"
+msgstr ""
+
+#: blocks/layout.py:100
+msgid "Reusable Layout"
+msgstr ""
+
+#: blocks/layout.py:101
+msgid "Layout template with customizable content slots"
+msgstr ""
+
+#: blocks/slot_fill.py:96
+msgid "The slot identifier to fill (e.g., 'main', 'sidebar')"
+msgstr ""
+
+#: blocks/slot_fill.py:97
+msgid "Slot ID"
+msgstr ""
+
+#: blocks/slot_fill.py:113
+msgid "Content to inject into this slot"
+msgstr ""
+
+#: blocks/slot_fill.py:114
+msgid "Slot Content"
+msgstr ""
+
+#: blocks/slot_fill.py:123
+msgid "Slot Fill"
+msgstr ""
+
+#: blocks/slot_fill.py:124
+msgid "Fill a specific slot with content"
+msgstr ""
+
+#: models/reusable_block.py:106 models/reusable_block.py:244
+msgid "Reusable Block"
+msgstr ""
+
+#: models/reusable_block.py:184
+msgid "name"
+msgstr ""
+
+#: models/reusable_block.py:186
+msgid "Human-readable name for this reusable block"
+msgstr ""
+
+#: models/reusable_block.py:189
+msgid "slug"
+msgstr ""
+
+#: models/reusable_block.py:193
+msgid "URL-safe identifier, auto-generated from name"
+msgstr ""
+
+#: models/reusable_block.py:204
+msgid "content"
+msgstr ""
+
+#: models/reusable_block.py:205
+msgid "The content of this reusable block"
+msgstr ""
+
+#: models/reusable_block.py:245 wagtail_hooks.py:56
+msgid "Reusable Blocks"
+msgstr ""
+
+#: models/reusable_block.py:300
+#, python-format
+msgid ""
+"Circular reference detected: Block '%(name)s' (id=%(id)s) references itself "
+"in the dependency chain."
+msgstr ""
+
+#: models/reusable_block.py:320
+#, python-format
+msgid ""
+"Circular reference detected: Block '%(name)s' references block "
+"'%(ref_name)s' which creates a cycle. %(error)s"
+msgstr ""
+
+#: views/cache.py:41
+#, python-format
+msgid "Cache cleared for '%(name)s'."
+msgstr ""
+
+#: views/cache.py:75
+msgid "All ReusableBlock cache entries have been cleared."
+msgstr ""
+
+#: wagtail_hooks.py:133
+msgid "Clear Cache"
+msgstr ""

--- a/src/wagtail_reusable_blocks/models/reusable_block.py
+++ b/src/wagtail_reusable_blocks/models/reusable_block.py
@@ -8,6 +8,8 @@ from django.db import models
 from django.template.loader import render_to_string
 from django.utils.safestring import SafeString, mark_safe
 from django.utils.text import slugify
+from django.utils.translation import gettext
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, PublishingPanel
 from wagtail.blocks import RawHTMLBlock, RichTextBlock, TextBlock
 from wagtail.fields import StreamField
@@ -42,7 +44,7 @@ class _HeadInjectionBlock(TextBlock):  # type: ignore[misc]
 
     class Meta:
         icon = "code"
-        label = "Preview Head Injection"
+        label = _("Preview Head Injection")
 
 
 class _ReusableBlockChooserBlock(SnippetChooserBlock):  # type: ignore[misc]
@@ -85,7 +87,8 @@ class _ReusableBlockChooserBlock(SnippetChooserBlock):  # type: ignore[misc]
         if current_depth >= max_depth:
             return mark_safe(
                 '<div class="reusable-block-max-depth-warning">'
-                "Maximum nesting depth exceeded</div>"
+                + str(_("Maximum nesting depth exceeded"))
+                + "</div>"
             )
 
         try:
@@ -101,7 +104,7 @@ class _ReusableBlockChooserBlock(SnippetChooserBlock):  # type: ignore[misc]
 
     class Meta:
         icon = "snippet"
-        label = "Reusable Block"
+        label = _("Reusable Block")
 
 
 class ReusableBlock(
@@ -179,14 +182,16 @@ class ReusableBlock(
 
     # Fields
     name = models.CharField(
+        _("name"),
         max_length=MAX_NAME_LENGTH,
-        help_text="Human-readable name for this reusable block",
+        help_text=_("Human-readable name for this reusable block"),
     )
     slug = models.SlugField(
+        _("slug"),
         unique=True,
         max_length=MAX_NAME_LENGTH,
         blank=True,
-        help_text="URL-safe identifier, auto-generated from name",
+        help_text=_("URL-safe identifier, auto-generated from name"),
     )
     content = StreamField(
         [
@@ -197,7 +202,8 @@ class ReusableBlock(
         ],
         use_json_field=True,
         blank=True,
-        help_text="The content of this reusable block",
+        verbose_name=_("content"),
+        help_text=_("The content of this reusable block"),
     )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -236,8 +242,8 @@ class ReusableBlock(
         """Model metadata."""
 
         ordering = ["-updated_at"]
-        verbose_name = "Reusable Block"
-        verbose_name_plural = "Reusable Blocks"
+        verbose_name = _("Reusable Block")
+        verbose_name_plural = _("Reusable Blocks")
         indexes = [
             models.Index(fields=["slug"]),
         ]
@@ -291,8 +297,11 @@ class ReusableBlock(
         # Check for self-reference
         if self.pk in visited:
             raise ValidationError(
-                f"Circular reference detected: Block '{self.name}' (id={self.pk}) "
-                f"references itself in the dependency chain."
+                gettext(
+                    "Circular reference detected: Block '%(name)s' (id=%(id)s) "
+                    "references itself in the dependency chain."
+                )
+                % {"name": self.name, "id": self.pk}
             )
 
         # Add current block to visited set
@@ -308,8 +317,11 @@ class ReusableBlock(
             except ValidationError as e:
                 # Re-raise with additional context
                 raise ValidationError(
-                    f"Circular reference detected: Block '{self.name}' references "
-                    f"block '{block.name}' which creates a cycle. {str(e)}"
+                    gettext(
+                        "Circular reference detected: Block '%(name)s' references "
+                        "block '%(ref_name)s' which creates a cycle. %(error)s"
+                    )
+                    % {"name": self.name, "ref_name": block.name, "error": str(e)}
                 ) from e
 
     def _get_referenced_blocks(self) -> list["ReusableBlock"]:

--- a/src/wagtail_reusable_blocks/views/cache.py
+++ b/src/wagtail_reusable_blocks/views/cache.py
@@ -4,6 +4,7 @@ from django.contrib import messages
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
+from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 from wagtail.admin.auth import permission_denied
 
@@ -37,7 +38,7 @@ def clear_block_cache_view(request: HttpRequest, block_id: int) -> HttpResponse:
 
     messages.success(
         request,
-        f"Cache cleared for '{block.name}'.",
+        _("Cache cleared for '%(name)s'.") % {"name": block.name},
     )
 
     # Redirect back to the edit page
@@ -71,7 +72,7 @@ def clear_all_cache_view(request: HttpRequest) -> HttpResponse:
 
     messages.success(
         request,
-        "All ReusableBlock cache entries have been cleared.",
+        _("All ReusableBlock cache entries have been cleared."),
     )
 
     # Redirect back to the list page

--- a/src/wagtail_reusable_blocks/wagtail_hooks.py
+++ b/src/wagtail_reusable_blocks/wagtail_hooks.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from django.urls import include, path, reverse
 from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.admin.filters import WagtailFilterSet
 from wagtail.admin.ui.tables import LiveStatusTagColumn, UpdatedAtColumn
@@ -52,7 +53,7 @@ class ReusableBlockViewSet(SnippetViewSetType):  # type: ignore[misc]
 
     model = ReusableBlock
     icon = "snippet"
-    menu_label = "Reusable Blocks"
+    menu_label = _("Reusable Blocks")
     menu_order = 200
     add_to_admin_menu = True
 
@@ -129,7 +130,7 @@ def register_clear_cache_button(
 
     return [
         SnippetListingButton(
-            "Clear Cache",
+            _("Clear Cache"),
             reverse(
                 "wagtail_reusable_blocks:clear_block_cache",
                 args=[snippet.pk],


### PR DESCRIPTION
## Summary
- Mark all user-facing Python strings for translation using Django's gettext
- Generate PO file with 29 translatable strings

## Changes

### Files Modified (9 files)
| File | Changes |
|------|---------|
| `apps.py` | `verbose_name` |
| `models/reusable_block.py` | Field labels, help_text, verbose_name, ValidationError messages |
| `wagtail_hooks.py` | `menu_label`, button labels |
| `blocks/chooser.py` | Warning messages |
| `blocks/layout.py` | help_text, labels |
| `blocks/slot_fill.py` | help_text, labels |
| `blocks/image.py` | help_text, labels |
| `blocks/head_injection.py` | labels |
| `views/cache.py` | Success messages |

### PO File Updated
- `locale/en/LC_MESSAGES/django.po` - 29 translatable strings extracted

### String Categories
- Model verbose_name: `Reusable Block`, `Reusable Blocks`
- Field labels: `name`, `slug`, `content`
- Help texts: `Human-readable name...`, `URL-safe identifier...`
- Block labels: `Image`, `Reusable Layout`, `Slot Fill`, etc.
- Error messages: `Maximum nesting depth exceeded`, `Circular reference detected...`
- UI messages: `Clear Cache`, `Cache cleared for...`

## Test plan
- [x] All 296 tests pass
- [x] `makemessages` generates valid PO file
- [x] No unmarked user-facing strings remain

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)