### PR TITLE
feat: mark template strings for translation (i18n)

### DIFF
--- a/src/wagtail_reusable_blocks/locale/en/LC_MESSAGES/django.po
+++ b/src/wagtail_reusable_blocks/locale/en/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wagtail-reusable-blocks\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-08 20:16+0900\n"
+"POT-Creation-Date: 2025-12-08 20:20+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
@@ -124,6 +124,11 @@ msgstr ""
 msgid ""
 "Circular reference detected: Block '%(name)s' references block "
 "'%(ref_name)s' which creates a cycle. %(error)s"
+msgstr ""
+
+#: templates/wagtail_reusable_blocks/preview.html:7
+#, python-format
+msgid "Preview: %(name)s"
 msgstr ""
 
 #: views/cache.py:41

--- a/src/wagtail_reusable_blocks/templates/wagtail_reusable_blocks/preview.html
+++ b/src/wagtail_reusable_blocks/templates/wagtail_reusable_blocks/preview.html
@@ -1,15 +1,15 @@
+{% load i18n wagtailcore_tags %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Preview: {{ block.name }}</title>
+    <title>{% blocktranslate with name=block.name %}Preview: {{ name }}{% endblocktranslate %}</title>
     {% for head_content in head_injection_content %}
     {{ head_content|safe }}
     {% endfor %}
 </head>
 <body>
-    {% load wagtailcore_tags %}
     {% include_block block.content %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Mark template strings for translation using Django template tags
- Add `{% blocktranslate %}` for preview title

## Changes

### Templates Audited
| Template | User-facing strings | Action |
|----------|-------------------|--------|
| `preview.html` | `Preview: {{ name }}` | Marked with `{% blocktranslate %}` |
| `reusable_block.html` | None (content output only) | No changes needed |
| `blocks/image.html` | None (image output only) | No changes needed |

### PO File Updated
- Added: `Preview: %(name)s`

## Dependency
This PR depends on #110 (feature/104-i18n-python-strings)

## Test plan
- [x] All 296 tests pass
- [x] `makemessages` extracts template string
- [x] Preview template renders correctly

Closes #105

