### PR TITLE
chore: add Transifex integration for translations

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+
+[o:kkm-horikawa:p:wagtail-reusable-blocks:r:djangopo]
+file_filter = src/wagtail_reusable_blocks/locale/<lang>/LC_MESSAGES/django.po
+source_file = src/wagtail_reusable_blocks/locale/en/LC_MESSAGES/django.po
+source_lang = en
+type = PO


### PR DESCRIPTION
## Summary
- Add `.tx/config` for Transifex GitHub integration
- Enables automated translation synchronization between GitHub and Transifex

## Test plan
- [x] Config file syntax is valid
- [ ] Transifex GitHub integration recognizes the config file

Closes #106

