### PR TITLE
docs: Move Philosophy section to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,24 @@
 [![codecov](https://codecov.io/gh/kkm-horikawa/wagtail-reusable-blocks/branch/develop/graph/badge.svg)](https://codecov.io/gh/kkm-horikawa/wagtail-reusable-blocks)
 [![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
-A Wagtail CMS extension for creating **reusable content blocks** that can be shared across multiple pages.
+## Philosophy
 
-## What is this?
+> "The best user interface for a programmer is usually a programming language."
+> — [The Zen of Wagtail](https://docs.wagtail.org/en/stable/getting_started/the_zen_of_wagtail.html)
 
-Create content blocks once and reuse them across your Wagtail site. When you update a reusable block, all pages using it automatically reflect the changes.
+We wholeheartedly embrace Wagtail's philosophy. Wagtail provides powerful systems like StreamField and StructBlock while keeping the core lightweight—free from features that may be unnecessary for some users. Many developers choose Wagtail over WordPress precisely because of this design philosophy.
 
-**Think of it like WordPress Gutenberg's "Synced Patterns" (formerly Reusable Blocks), but for Wagtail.**
+However, through building Wagtail sites, we discovered a practical limitation: **Wagtail excels at repository-level implementation, but the admin interface can become rigid** when dealing with shared layouts.
+
+For example, if you create a block for a sidebar or header used across pages, it becomes difficult to customize portions of that block on a per-page basis. As we focused more on UX, we noticed our block definitions multiplying and field counts exploding.
+
+This led to a realization: **Just as code is the best interface for developers, HTML is the most flexible interface for content layouts in the admin.** If editors could write flexible layouts in HTML and inject dynamic content (images, rich text) into specific areas, that would be the ultimate Wagtail editing experience.
+
+That's why we built this library.
+
+Programmers want to keep their repositories clean. They don't want to modify block definitions and risk deployments for minor layout tweaks. With wagtail-reusable-blocks, you can bring the flexibility of programming—Wagtail's core strength—directly into the admin interface.
+
+**Write layouts in HTML. Fill slots with content. Deploy zero code changes.**
 
 ## Key Features
 
@@ -536,25 +547,6 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 ## License
 
 BSD 3-Clause License. See [LICENSE](LICENSE) for details.
-
-## Philosophy
-
-> "The best user interface for a programmer is usually a programming language."
-> — [The Zen of Wagtail](https://docs.wagtail.org/en/stable/getting_started/the_zen_of_wagtail.html)
-
-We wholeheartedly embrace Wagtail's philosophy. Wagtail provides powerful systems like StreamField and StructBlock while keeping the core lightweight—free from features that may be unnecessary for some users. Many developers choose Wagtail over WordPress precisely because of this design philosophy.
-
-However, through building Wagtail sites, we discovered a practical limitation: **Wagtail excels at repository-level implementation, but the admin interface can become rigid** when dealing with shared layouts.
-
-For example, if you create a block for a sidebar or header used across pages, it becomes difficult to customize portions of that block on a per-page basis. As we focused more on UX, we noticed our block definitions multiplying and field counts exploding.
-
-This led to a realization: **Just as code is the best interface for developers, HTML is the most flexible interface for content layouts in the admin.** If editors could write flexible layouts in HTML and inject dynamic content (images, rich text) into specific areas, that would be the ultimate Wagtail editing experience.
-
-That's why we built this library.
-
-Programmers want to keep their repositories clean. They don't want to modify block definitions and risk deployments for minor layout tweaks. With wagtail-reusable-blocks, you can bring the flexibility of programming—Wagtail's core strength—directly into the admin interface.
-
-**Write layouts in HTML. Fill slots with content. Deploy zero code changes.**
 
 ## Inspiration
 


### PR DESCRIPTION
## Summary

- Move Philosophy section from bottom to top of README (replacing "What is this?")
- Remove duplicate Philosophy section
- Keep WordPress reference in Inspiration section

## Why

The library's core value proposition should be immediately visible. Starting with Wagtail's philosophy and explaining how this library extends it to the admin interface is more compelling than "it's like WordPress Synced Patterns."

## Before/After

**Before:** "Think of it like WordPress Gutenberg's Synced Patterns..."

**After:** Wagtail philosophy quote → Problem statement → Solution → Tagline

🤖 Generated with [Claude Code](https://claude.com/claude-code)