### PR TITLE
chore: Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: uv run mypy src/
+        language: system
+        types: [python]
+        files: ^src/
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "django-stubs>=5.1",
     "tox>=4.0",
     "tox-uv>=1.0",
+    "pre-commit>=4.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## 関連Issue
Closes #181

## Summary
- Add `.pre-commit-config.yaml` with OSS best practice hooks
- Add `pre-commit>=4.0` to dev dependencies

## Hooks
- `trailing-whitespace`
- `end-of-file-fixer`
- `check-yaml`
- `check-added-large-files`
- `check-merge-conflict`
- `ruff` (lint + auto-fix)
- `ruff-format`
- `mypy` (local hook using project venv)

## Auto-fixes Applied
- `ruff-format` applied to `tests/test_i18n.py`

## Test
- [x] `pre-commit run --all-files` passes