### PR TITLE
docs: Clarify that data-slot attributes are library-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Go to **Snippets > Reusable Blocks** and create a new block:
 </div>
 ```
 
-**Slot attributes:**
+**Slot attributes** (custom HTML attributes defined by this library):
 - `data-slot="slot-id"` - **Required.** Unique identifier (e.g., "main", "sidebar-extra")
 - `data-slot-label="Display Name"` - **Optional.** Human-readable label shown in admin
 - Child elements - **Optional.** Default content displayed if slot is not filled


### PR DESCRIPTION
## Summary
- Clarify that `data-slot` and `data-slot-label` are custom HTML attributes defined by this library, not standard HTML attributes

## Test plan
- [ ] Verify README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)