### PR TITLE
Release v0.8.0 - REST API support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ Issues = "https://github.com/kkm-horikawa/wagtail-reusable-blocks/issues"
 Changelog = "https://github.com/kkm-horikawa/wagtail-reusable-blocks/releases"
 
 [project.optional-dependencies]
+api = [
+    "djangorestframework>=3.14",
+]
 editor = [
     "wagtail-html-editor>=1.0.0",
 ]
@@ -55,6 +58,10 @@ dev = [
     "tox>=4.0",
     "tox-uv>=1.0",
     "pre-commit>=4.0",
+]
+e2e = [
+    "pytest-playwright>=0.5",
+    "requests>=2.28",
 ]
 
 [build-system]
@@ -115,7 +122,10 @@ quote-style = "double"
 DJANGO_SETTINGS_MODULE = "tests.settings"
 pythonpath = [".", "src"]
 testpaths = ["tests"]
-addopts = "-v --tb=short"
+addopts = "-v --tb=short -m 'not e2e'"
+markers = [
+    "e2e: End-to-End tests with Playwright (deselected by default)",
+]
 
 [tool.mypy]
 python_version = "3.10"
@@ -126,6 +136,10 @@ exclude = ["tests/"]
 
 [[tool.mypy.overrides]]
 module = ["wagtail.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["rest_framework.*"]
 ignore_missing_imports = true
 
 [tool.django-stubs]
@@ -153,6 +167,7 @@ deps =
     pytest-django>=4.8
     pytest-cov>=4.1
     pytest-benchmark>=4.0
+    djangorestframework>=3.14
     django42: Django~=4.2.0
     django51: Django~=5.1.0
     django52: Django~=5.2.0

--- a/src/wagtail_reusable_blocks/api/__init__.py
+++ b/src/wagtail_reusable_blocks/api/__init__.py
@@ -1,0 +1,35 @@
+"""REST API support for wagtail-reusable-blocks.
+
+Provides two types of API endpoints:
+
+1. Wagtail API v2 (read-only):
+   Uses Wagtail's built-in API framework for public content delivery.
+
+2. DRF ModelViewSet (full CRUD):
+   Uses Django REST Framework for complete CRUD operations.
+
+Setup:
+    # Option A: Wagtail API v2 (read-only)
+    from wagtail.api.v2.router import WagtailAPIRouter
+    from wagtail_reusable_blocks.api import ReusableBlockAPIViewSet
+
+    api_router = WagtailAPIRouter("wagtailapi")
+    api_router.register_endpoint("reusable-blocks", ReusableBlockAPIViewSet)
+
+    # Option B: DRF CRUD
+    from rest_framework.routers import DefaultRouter
+    from wagtail_reusable_blocks.api import ReusableBlockModelViewSet
+
+    router = DefaultRouter()
+    router.register("reusable-blocks", ReusableBlockModelViewSet)
+"""
+
+from wagtail_reusable_blocks.api.views import (
+    ReusableBlockAPIViewSet,
+    ReusableBlockModelViewSet,
+)
+
+__all__ = [
+    "ReusableBlockAPIViewSet",
+    "ReusableBlockModelViewSet",
+]

--- a/src/wagtail_reusable_blocks/api/serializers.py
+++ b/src/wagtail_reusable_blocks/api/serializers.py
@@ -1,0 +1,122 @@
+"""Serializers for wagtail-reusable-blocks API."""
+
+from typing import Any
+
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.utils.text import slugify
+from rest_framework import fields as drf_fields
+from rest_framework import serializers
+
+from wagtail_reusable_blocks.models import ReusableBlock
+
+
+class StreamFieldField(drf_fields.Field):  # type: ignore[misc]
+    """Custom DRF field for Wagtail StreamField serialization.
+
+    Converts StreamValue to JSON-serializable list on read,
+    and accepts JSON list on write.
+    """
+
+    def to_representation(self, value: Any) -> list[Any]:
+        """Convert StreamValue to a JSON-serializable list."""
+        if not value:
+            return []
+        request = self.context.get("request")
+        return value.stream_block.get_api_representation(value, request)  # type: ignore[no-any-return]
+
+    def to_internal_value(self, data: Any) -> list[Any]:
+        """Accept a JSON list of stream blocks."""
+        if data is None:
+            return []
+        if not isinstance(data, list):
+            raise serializers.ValidationError(
+                "Content must be a list of stream blocks."
+            )
+        return data
+
+
+class ReusableBlockSerializer(serializers.ModelSerializer):  # type: ignore[misc]
+    """Serializer for ReusableBlock model with StreamField support.
+
+    Handles:
+    - StreamField content as JSON (read/write)
+    - Auto-generated slug from name
+    - Circular reference validation
+    - Revision creation on save
+    """
+
+    content = StreamFieldField(required=False, default=list)
+
+    class Meta:
+        model = ReusableBlock
+        fields = [
+            "id",
+            "name",
+            "slug",
+            "content",
+            "live",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = ["id", "created_at", "updated_at", "live"]
+
+    def validate_slug(self, value: str) -> str:
+        """Validate slug uniqueness, excluding the current instance on update."""
+        instance = self.instance
+        qs = ReusableBlock.objects.filter(slug=value)
+        if instance is not None:
+            qs = qs.exclude(pk=instance.pk)
+        if qs.exists():
+            raise serializers.ValidationError(
+                "A reusable block with this slug already exists."
+            )
+        return value
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        """Run model-level validation including circular reference detection."""
+        # Auto-generate slug from name when:
+        # - Creating (instance is None) and no slug provided
+        # - Updating with slug explicitly set to empty string
+        if attrs.get("name") and not attrs.get("slug"):
+            if self.instance is None or "slug" in attrs:
+                attrs["slug"] = slugify(attrs["name"])
+
+        # validate_slug only runs for explicit input; auto-generated slugs need checking here
+        slug = attrs.get("slug")
+        if slug:
+            qs = ReusableBlock.objects.filter(slug=slug)
+            if self.instance is not None:
+                qs = qs.exclude(pk=self.instance.pk)
+            if qs.exists():
+                raise serializers.ValidationError(
+                    {"slug": "A reusable block with this slug already exists."}
+                )
+
+        return attrs
+
+    def create(self, validated_data: dict[str, Any]) -> ReusableBlock:
+        """Create a new ReusableBlock and save an initial revision."""
+        instance = ReusableBlock(**validated_data)
+        self._run_full_clean(instance)
+        instance.save()
+        instance.save_revision()
+        return instance
+
+    def update(
+        self, instance: ReusableBlock, validated_data: dict[str, Any]
+    ) -> ReusableBlock:
+        """Update a ReusableBlock and save a revision."""
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        self._run_full_clean(instance)
+        instance.save()
+        instance.save_revision()
+        return instance
+
+    @staticmethod
+    def _run_full_clean(instance: ReusableBlock) -> None:
+        """Run full_clean and convert Django ValidationError to DRF ValidationError."""
+        try:
+            instance.full_clean()
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError(exc.message_dict) from exc

--- a/src/wagtail_reusable_blocks/api/views.py
+++ b/src/wagtail_reusable_blocks/api/views.py
@@ -1,0 +1,132 @@
+"""API views for wagtail-reusable-blocks."""
+
+from typing import Any
+
+from django.utils.module_loading import import_string
+from rest_framework import permissions, viewsets
+from wagtail.api.v2.filters import FieldsFilter, OrderingFilter, SearchFilter
+from wagtail.api.v2.views import BaseAPIViewSet
+
+from wagtail_reusable_blocks.api.serializers import ReusableBlockSerializer
+from wagtail_reusable_blocks.conf import get_setting
+from wagtail_reusable_blocks.models import ReusableBlock
+
+
+def _resolve_classes(setting_key: str) -> list[type[Any]] | None:
+    """Resolve class paths from settings to actual classes.
+
+    Args:
+        setting_key: The setting key containing class paths.
+
+    Returns:
+        List of resolved classes, or None if the setting is None.
+    """
+    classes = get_setting(setting_key)
+    if classes is None:
+        return None
+
+    resolved: list[type[Any]] = []
+    for cls in classes:
+        if isinstance(cls, str):
+            resolved.append(import_string(cls))
+        else:
+            resolved.append(cls)
+    return resolved
+
+
+class ReusableBlockAPIViewSet(BaseAPIViewSet):  # type: ignore[misc]
+    """Read-only API endpoint for ReusableBlock (Wagtail API v2 compatible).
+
+    Provides:
+    - GET /api/v2/reusable-blocks/ (list)
+    - GET /api/v2/reusable-blocks/<id>/ (detail)
+
+    Only returns published (live) blocks.
+
+    Usage::
+
+        from wagtail.api.v2.router import WagtailAPIRouter
+        from wagtail_reusable_blocks.api import ReusableBlockAPIViewSet
+
+        api_router = WagtailAPIRouter("wagtailapi")
+        api_router.register_endpoint("reusable-blocks", ReusableBlockAPIViewSet)
+    """
+
+    model = ReusableBlock
+    body_fields = BaseAPIViewSet.body_fields + [
+        "name",
+        "slug",
+        "content",
+        "live",
+        "created_at",
+        "updated_at",
+    ]
+    listing_default_fields = BaseAPIViewSet.listing_default_fields + [
+        "name",
+        "slug",
+        "live",
+        "updated_at",
+    ]
+    filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
+    name = "reusable_blocks"
+
+    def get_queryset(self) -> Any:
+        """Return only live (published) blocks."""
+        return ReusableBlock.objects.filter(live=True)
+
+
+class ReusableBlockModelViewSet(viewsets.ModelViewSet):  # type: ignore[misc]
+    """Full CRUD API endpoint for ReusableBlock (DRF-based).
+
+    Provides:
+    - GET    /reusable-blocks/      (list)
+    - POST   /reusable-blocks/      (create)
+    - GET    /reusable-blocks/<id>/ (retrieve)
+    - PUT    /reusable-blocks/<id>/ (update)
+    - PATCH  /reusable-blocks/<id>/ (partial update)
+    - DELETE /reusable-blocks/<id>/ (destroy)
+
+    Usage::
+
+        from rest_framework.routers import DefaultRouter
+        from wagtail_reusable_blocks.api import ReusableBlockModelViewSet
+
+        router = DefaultRouter()
+        router.register("reusable-blocks", ReusableBlockModelViewSet)
+    """
+
+    queryset = ReusableBlock.objects.all()
+    serializer_class = ReusableBlockSerializer
+    lookup_field = "pk"
+
+    def get_permissions(self) -> list[permissions.BasePermission]:
+        """Get permission classes from settings."""
+        classes = _resolve_classes("API_PERMISSION_CLASSES")
+        if classes is None:
+            return []
+        return [cls() for cls in classes]
+
+    def get_authenticators(self) -> list[Any]:
+        """Get authentication classes from settings, or use DRF defaults."""
+        classes = _resolve_classes("API_AUTHENTICATION_CLASSES")
+        if classes is None:
+            return super().get_authenticators()  # type: ignore[no-any-return]
+        return [cls() for cls in classes]
+
+    def get_queryset(self) -> Any:
+        """Return all blocks, with optional filtering."""
+        qs = ReusableBlock.objects.all()
+
+        slug = self.request.query_params.get("slug")
+        if slug:
+            qs = qs.filter(slug=slug)
+
+        live = self.request.query_params.get("live")
+        if live is not None:
+            qs = qs.filter(live=live.lower() in ("true", "1", "yes"))
+
+        search = self.request.query_params.get("search")
+        if search:
+            qs = qs.filter(name__icontains=search)
+
+        return qs

--- a/src/wagtail_reusable_blocks/conf.py
+++ b/src/wagtail_reusable_blocks/conf.py
@@ -20,6 +20,11 @@ DEFAULTS = {
     "CACHE_PREFIX": "wrb:",
     # v0.5.0 settings - Preview
     "PREVIEW_TEMPLATE": "wagtail_reusable_blocks/preview.html",
+    # v0.8.0 settings - API
+    "API_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+    ],
+    "API_AUTHENTICATION_CLASSES": None,  # None means use DRF defaults
 }
 
 

--- a/src/wagtail_reusable_blocks/migrations/0006_alter_reusableblock_content_alter_reusableblock_name_and_more.py
+++ b/src/wagtail_reusable_blocks/migrations/0006_alter_reusableblock_content_alter_reusableblock_name_and_more.py
@@ -5,25 +5,62 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('wagtail_reusable_blocks', '0005_add_head_injection_block'),
+        ("wagtail_reusable_blocks", "0005_add_head_injection_block"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='reusableblock',
-            name='content',
-            field=wagtail.fields.StreamField([('rich_text', 0), ('raw_html', 1), ('reusable_block', 2), ('head_injection', 3)], blank=True, block_lookup={0: ('wagtail.blocks.RichTextBlock', (), {}), 1: ('wagtail_reusable_blocks.models.reusable_block._ContentHTMLBlock', (), {}), 2: ('wagtail_reusable_blocks.models.reusable_block._ReusableBlockChooserBlock', (), {}), 3: ('wagtail_reusable_blocks.models.reusable_block._HeadInjectionBlock', (), {})}, help_text='The content of this reusable block', verbose_name='content'),
+            model_name="reusableblock",
+            name="content",
+            field=wagtail.fields.StreamField(
+                [
+                    ("rich_text", 0),
+                    ("raw_html", 1),
+                    ("reusable_block", 2),
+                    ("head_injection", 3),
+                ],
+                blank=True,
+                block_lookup={
+                    0: ("wagtail.blocks.RichTextBlock", (), {}),
+                    1: (
+                        "wagtail_reusable_blocks.models.reusable_block._ContentHTMLBlock",
+                        (),
+                        {},
+                    ),
+                    2: (
+                        "wagtail_reusable_blocks.models.reusable_block._ReusableBlockChooserBlock",
+                        (),
+                        {},
+                    ),
+                    3: (
+                        "wagtail_reusable_blocks.models.reusable_block._HeadInjectionBlock",
+                        (),
+                        {},
+                    ),
+                },
+                help_text="The content of this reusable block",
+                verbose_name="content",
+            ),
         ),
         migrations.AlterField(
-            model_name='reusableblock',
-            name='name',
-            field=models.CharField(help_text='Human-readable name for this reusable block', max_length=255, verbose_name='name'),
+            model_name="reusableblock",
+            name="name",
+            field=models.CharField(
+                help_text="Human-readable name for this reusable block",
+                max_length=255,
+                verbose_name="name",
+            ),
         ),
         migrations.AlterField(
-            model_name='reusableblock',
-            name='slug',
-            field=models.SlugField(blank=True, help_text='URL-safe identifier, auto-generated from name', max_length=255, unique=True, verbose_name='slug'),
+            model_name="reusableblock",
+            name="slug",
+            field=models.SlugField(
+                blank=True,
+                help_text="URL-safe identifier, auto-generated from name",
+                max_length=255,
+                unique=True,
+                verbose_name="slug",
+            ),
         ),
     ]

--- a/src/wagtail_reusable_blocks/models/reusable_block.py
+++ b/src/wagtail_reusable_blocks/models/reusable_block.py
@@ -11,6 +11,7 @@ from django.utils.text import slugify
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, PublishingPanel
+from wagtail.api import APIField
 from wagtail.blocks import RawHTMLBlock, RichTextBlock, TextBlock
 from wagtail.fields import StreamField
 from wagtail.models import (
@@ -33,7 +34,7 @@ try:
         EnhancedHTMLBlock as _HTMLBlockBase,
     )
 except ImportError:
-    _HTMLBlockBase = RawHTMLBlock  # type: ignore[misc]
+    _HTMLBlockBase = RawHTMLBlock  # type: ignore[misc,unused-ignore]
 
 
 class _ContentHTMLBlock(_HTMLBlockBase):  # type: ignore[misc]
@@ -251,6 +252,16 @@ class ReusableBlock(
         FieldPanel("slug"),
         FieldPanel("content"),
         PublishingPanel(),
+    ]
+
+    # API fields for Wagtail API v2
+    api_fields = [
+        APIField("name"),
+        APIField("slug"),
+        APIField("content"),
+        APIField("created_at"),
+        APIField("updated_at"),
+        APIField("live"),
     ]
 
     # Search configuration

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -6,6 +6,9 @@ This is a minimal configuration for running tests.
 
 import os
 
+# Required for Playwright E2E tests (live_server + Django ORM in same thread)
+os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
+
 # Build paths inside the project
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -38,6 +41,8 @@ INSTALLED_APPS = [
     "wagtail.contrib.forms",
     "wagtail.contrib.redirects",
     "taggit",
+    # Third-party
+    "rest_framework",
     # Our app
     "wagtail_reusable_blocks",
 ]
@@ -110,6 +115,14 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.dummy.DummyCache",
     }
+}
+
+# DRF settings for testing
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.BasicAuthentication",
+    ],
 }
 
 # Disable caching in tests by default

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1,0 +1,352 @@
+"""Response schema validation tests for DRF API endpoints.
+
+schemathesis-based fuzzing is skipped because OpenAPI schema is not yet introduced.
+Each CRUD endpoint's response structure is verified against the expected schema.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from wagtail_reusable_blocks.models import ReusableBlock
+
+User = get_user_model()
+
+LIST_FIELDS = {"id", "name", "slug", "content", "live", "created_at", "updated_at"}
+DETAIL_FIELDS = LIST_FIELDS
+READ_ONLY_FIELDS = {"id", "created_at", "updated_at", "live"}
+
+
+@pytest.fixture
+def api_admin_user(db):
+    return User.objects.create_superuser(
+        username="api_admin", email="api_admin@example.com", password="password"
+    )
+
+
+@pytest.fixture
+def api_client(api_admin_user):
+    client = APIClient()
+    client.force_authenticate(user=api_admin_user)
+    return client
+
+
+@pytest.fixture
+def sample_block(db):
+    block = ReusableBlock(
+        name="Sample Block",
+        slug="sample-block",
+        content=[{"type": "rich_text", "value": "<p>Hello</p>"}],
+    )
+    block.save()
+    return block
+
+
+@pytest.fixture
+def multiple_blocks(db):
+    blocks = []
+    for i in range(3):
+        block = ReusableBlock(
+            name=f"Block {i}",
+            slug=f"block-{i}",
+            content=[{"type": "rich_text", "value": f"<p>Content {i}</p>"}],
+        )
+        block.save()
+        blocks.append(block)
+    return blocks
+
+
+def _assert_field_types(data):
+    """Validate field types for a single block response."""
+    assert isinstance(data["id"], int)
+    assert isinstance(data["name"], str)
+    assert isinstance(data["slug"], str)
+    assert isinstance(data["content"], list)
+    assert isinstance(data["live"], bool)
+    assert isinstance(data["created_at"], str)
+    assert isinstance(data["updated_at"], str)
+
+
+class TestListEndpointSchema:
+    """GET /api/reusable-blocks/ response schema validation."""
+
+    @pytest.mark.django_db
+    def test_list_returns_array(self, api_client, multiple_blocks):
+        """Verify that the list endpoint returns an array."""
+        response = api_client.get("/api/reusable-blocks/")
+        assert response.status_code == 200
+        assert isinstance(response.json(), list)
+
+    @pytest.mark.django_db
+    def test_list_item_has_all_fields(self, api_client, sample_block):
+        """Verify that each item in the list contains all expected fields."""
+        response = api_client.get("/api/reusable-blocks/")
+        data = response.json()
+        assert len(data) >= 1
+        assert set(data[0].keys()) == LIST_FIELDS
+
+    @pytest.mark.django_db
+    def test_list_item_field_types(self, api_client, sample_block):
+        """Verify field types for each item in the list."""
+        response = api_client.get("/api/reusable-blocks/")
+        _assert_field_types(response.json()[0])
+
+    @pytest.mark.django_db
+    def test_empty_list(self, api_client, db):
+        """Verify that an empty array is returned when no blocks exist."""
+        response = api_client.get("/api/reusable-blocks/")
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+class TestRetrieveEndpointSchema:
+    """GET /api/reusable-blocks/{id}/ response schema validation."""
+
+    @pytest.mark.django_db
+    def test_retrieve_has_all_fields(self, api_client, sample_block):
+        """Verify that the detail endpoint contains all expected fields."""
+        response = api_client.get(f"/api/reusable-blocks/{sample_block.pk}/")
+        assert response.status_code == 200
+        assert set(response.json().keys()) == DETAIL_FIELDS
+
+    @pytest.mark.django_db
+    def test_retrieve_field_types(self, api_client, sample_block):
+        """Verify field types of the detail endpoint response."""
+        response = api_client.get(f"/api/reusable-blocks/{sample_block.pk}/")
+        _assert_field_types(response.json())
+
+    @pytest.mark.django_db
+    def test_retrieve_field_values(self, api_client, sample_block):
+        """Verify that field values match the model."""
+        response = api_client.get(f"/api/reusable-blocks/{sample_block.pk}/")
+        data = response.json()
+        assert data["id"] == sample_block.pk
+        assert data["name"] == "Sample Block"
+        assert data["slug"] == "sample-block"
+
+    @pytest.mark.django_db
+    def test_retrieve_not_found(self, api_client, db):
+        """Verify that a 404 is returned for a non-existent ID."""
+        response = api_client.get("/api/reusable-blocks/99999/")
+        assert response.status_code == 404
+
+
+class TestCreateEndpointSchema:
+    """POST /api/reusable-blocks/ response schema validation."""
+
+    @pytest.mark.django_db
+    def test_create_returns_all_fields(self, api_client):
+        """Verify that the creation response contains all expected fields."""
+        payload = {
+            "name": "New Block",
+            "slug": "new-block",
+            "content": [{"type": "rich_text", "value": "<p>New</p>"}],
+        }
+        response = api_client.post("/api/reusable-blocks/", payload, format="json")
+        assert response.status_code == 201
+        assert set(response.json().keys()) == DETAIL_FIELDS
+
+    @pytest.mark.django_db
+    def test_create_field_types(self, api_client):
+        """Verify field types of the creation response."""
+        payload = {
+            "name": "Typed Block",
+            "slug": "typed-block",
+            "content": [],
+        }
+        response = api_client.post("/api/reusable-blocks/", payload, format="json")
+        assert response.status_code == 201
+        _assert_field_types(response.json())
+
+    @pytest.mark.django_db
+    def test_create_read_only_fields_ignored(self, api_client):
+        """Verify that read-only fields in input are ignored."""
+        payload = {
+            "name": "Readonly Test",
+            "slug": "readonly-test",
+            "content": [],
+            "id": 99999,
+            "live": True,
+        }
+        response = api_client.post("/api/reusable-blocks/", payload, format="json")
+        assert response.status_code == 201
+        data = response.json()
+        assert data["id"] != 99999
+
+    @pytest.mark.django_db
+    def test_create_auto_slug(self, api_client):
+        """Verify that slug is auto-generated from the name."""
+        payload = {"name": "Auto Slug Test", "content": []}
+        response = api_client.post("/api/reusable-blocks/", payload, format="json")
+        assert response.status_code == 201
+        assert response.json()["slug"] == "auto-slug-test"
+
+    @pytest.mark.django_db
+    def test_create_validation_error_schema(self, api_client, sample_block):
+        """Verify the response structure of a validation error."""
+        payload = {
+            "name": "Duplicate",
+            "slug": "sample-block",
+            "content": [],
+        }
+        response = api_client.post("/api/reusable-blocks/", payload, format="json")
+        assert response.status_code == 400
+        data = response.json()
+        assert isinstance(data, dict)
+
+    @pytest.mark.django_db
+    def test_create_missing_name(self, api_client):
+        """Verify that a validation error is returned when name is missing."""
+        payload = {"content": []}
+        response = api_client.post("/api/reusable-blocks/", payload, format="json")
+        assert response.status_code == 400
+
+
+class TestUpdateEndpointSchema:
+    """PUT /api/reusable-blocks/{id}/ response schema validation."""
+
+    @pytest.mark.django_db
+    def test_update_returns_all_fields(self, api_client, sample_block):
+        """Verify that the update response contains all expected fields."""
+        payload = {
+            "name": "Updated Block",
+            "slug": "updated-block",
+            "content": [],
+        }
+        response = api_client.put(
+            f"/api/reusable-blocks/{sample_block.pk}/", payload, format="json"
+        )
+        assert response.status_code == 200
+        assert set(response.json().keys()) == DETAIL_FIELDS
+
+    @pytest.mark.django_db
+    def test_update_field_types(self, api_client, sample_block):
+        """Verify field types of the update response."""
+        payload = {
+            "name": "Type Check",
+            "slug": "type-check",
+            "content": [{"type": "rich_text", "value": "<p>Updated</p>"}],
+        }
+        response = api_client.put(
+            f"/api/reusable-blocks/{sample_block.pk}/", payload, format="json"
+        )
+        _assert_field_types(response.json())
+
+    @pytest.mark.django_db
+    def test_update_reflects_changes(self, api_client, sample_block):
+        """Verify that updated values are reflected in the response."""
+        payload = {
+            "name": "Changed Name",
+            "slug": "changed-name",
+            "content": [],
+        }
+        response = api_client.put(
+            f"/api/reusable-blocks/{sample_block.pk}/", payload, format="json"
+        )
+        data = response.json()
+        assert data["name"] == "Changed Name"
+        assert data["slug"] == "changed-name"
+        assert data["id"] == sample_block.pk
+
+
+class TestPartialUpdateEndpointSchema:
+    """PATCH /api/reusable-blocks/{id}/ response schema validation."""
+
+    @pytest.mark.django_db
+    def test_partial_update_returns_all_fields(self, api_client, sample_block):
+        """Verify that the partial update response contains all expected fields."""
+        payload = {"name": "Patched Block"}
+        response = api_client.patch(
+            f"/api/reusable-blocks/{sample_block.pk}/", payload, format="json"
+        )
+        assert response.status_code == 200
+        assert set(response.json().keys()) == DETAIL_FIELDS
+
+    @pytest.mark.django_db
+    def test_partial_update_preserves_unchanged(self, api_client, sample_block):
+        """Verify that unchanged fields are preserved during partial update."""
+        payload = {"name": "Only Name Changed"}
+        response = api_client.patch(
+            f"/api/reusable-blocks/{sample_block.pk}/", payload, format="json"
+        )
+        data = response.json()
+        assert data["name"] == "Only Name Changed"
+        assert data["slug"] == "sample-block"
+
+
+class TestDeleteEndpointSchema:
+    """DELETE /api/reusable-blocks/{id}/ response schema validation."""
+
+    @pytest.mark.django_db
+    def test_delete_returns_204(self, api_client, sample_block):
+        """Verify that delete returns 204 No Content."""
+        response = api_client.delete(f"/api/reusable-blocks/{sample_block.pk}/")
+        assert response.status_code == 204
+
+    @pytest.mark.django_db
+    def test_delete_no_body(self, api_client, sample_block):
+        """Verify that the delete response has no body."""
+        response = api_client.delete(f"/api/reusable-blocks/{sample_block.pk}/")
+        assert response.content == b""
+
+    @pytest.mark.django_db
+    def test_delete_not_found(self, api_client, db):
+        """Verify that deleting a non-existent ID returns 404."""
+        response = api_client.delete("/api/reusable-blocks/99999/")
+        assert response.status_code == 404
+
+
+class TestContentFieldSchema:
+    """content field (StreamField JSON) schema validation."""
+
+    @pytest.mark.django_db
+    def test_content_is_list(self, api_client, sample_block):
+        """Verify that the content field is a list."""
+        response = api_client.get(f"/api/reusable-blocks/{sample_block.pk}/")
+        assert isinstance(response.json()["content"], list)
+
+    @pytest.mark.django_db
+    def test_empty_content(self, api_client):
+        """Verify that a block can be created with empty content."""
+        payload = {"name": "Empty Content", "slug": "empty-content", "content": []}
+        response = api_client.post("/api/reusable-blocks/", payload, format="json")
+        assert response.status_code == 201
+        assert response.json()["content"] == []
+
+    @pytest.mark.django_db
+    def test_content_with_stream_blocks(self, api_client, sample_block):
+        """Verify that the content field contains StreamBlock structure."""
+        response = api_client.get(f"/api/reusable-blocks/{sample_block.pk}/")
+        content = response.json()["content"]
+        assert len(content) >= 1
+        block = content[0]
+        assert "type" in block
+        assert "value" in block
+        assert "id" in block
+
+
+class TestAuthenticationSchema:
+    """Unauthenticated request response schema validation."""
+
+    @pytest.mark.django_db
+    def test_unauthenticated_list(self, db):
+        """Verify that an unauthenticated list request returns 403."""
+        client = APIClient()
+        response = client.get("/api/reusable-blocks/")
+        assert response.status_code == 403
+
+    @pytest.mark.django_db
+    def test_unauthenticated_create(self, db):
+        """Verify that an unauthenticated create request returns 403."""
+        client = APIClient()
+        payload = {"name": "Unauth", "slug": "unauth", "content": []}
+        response = client.post("/api/reusable-blocks/", payload, format="json")
+        assert response.status_code == 403
+
+    @pytest.mark.django_db
+    def test_unauthenticated_error_schema(self, db):
+        """Verify that the unauthenticated error response contains a detail field."""
+        client = APIClient()
+        response = client.get("/api/reusable-blocks/")
+        data = response.json()
+        assert "detail" in data

--- a/tests/test_api_e2e.py
+++ b/tests/test_api_e2e.py
@@ -1,0 +1,194 @@
+"""E2E tests for API-created content rendering in Wagtail admin.
+
+Verifies that ReusableBlocks created via the DRF API render correctly
+in the Wagtail admin snippet editing and preview views.
+"""
+
+import pytest
+
+playwright_sync_api = pytest.importorskip(
+    "playwright.sync_api", reason="playwright not installed"
+)
+Page = playwright_sync_api.Page
+expect = playwright_sync_api.expect
+
+import requests  # noqa: E402
+
+
+@pytest.fixture
+def authenticated_page(page: Page, live_server, admin_user) -> Page:
+    """Login to Wagtail admin and return authenticated page."""
+    page.goto(f"{live_server.url}/login/")
+    page.locator("#id_username").fill("admin")
+    page.locator("#id_password").fill("password")
+    page.locator("button[type='submit']").click()
+    page.wait_for_url(f"{live_server.url}/**")
+    return page
+
+
+@pytest.fixture
+def api_session(live_server, admin_user) -> requests.Session:
+    """Authenticated requests.Session for DRF API calls against live_server."""
+    session = requests.Session()
+    login_url = f"{live_server.url}/login/"
+    resp = session.get(login_url)
+    csrftoken = resp.cookies.get("csrftoken", "")
+    session.post(
+        login_url,
+        data={
+            "username": "admin",
+            "password": "password",
+            "csrfmiddlewaretoken": csrftoken,
+        },
+        headers={"Referer": login_url},
+    )
+    return session
+
+
+def _create_block_via_api(
+    session: requests.Session,
+    base_url: str,
+    name: str,
+    content: list,
+    slug: str | None = None,
+) -> dict:
+    """Create a ReusableBlock via the DRF API."""
+    payload: dict = {"name": name, "content": content}
+    if slug:
+        payload["slug"] = slug
+    csrftoken = session.cookies.get("csrftoken", "")
+    resp = session.post(
+        f"{base_url}/api/reusable-blocks/",
+        json=payload,
+        headers={
+            "X-CSRFToken": csrftoken,
+            "Referer": base_url,
+        },
+    )
+    assert resp.status_code == 201, f"API create failed: {resp.status_code} {resp.text}"
+    return resp.json()
+
+
+@pytest.mark.e2e
+@pytest.mark.django_db(transaction=True)
+def test_api_created_blocks_render_in_admin(
+    authenticated_page: Page,
+    api_session: requests.Session,
+    live_server,
+):
+    """API-created rich_text and raw_html blocks render correctly in admin preview.
+
+    Purpose: Verify that ReusableBlocks created via the DRF API (rich_text
+             and raw_html) appear in the Wagtail admin snippet listing and
+             render correctly in the edit view preview, ensuring the end-to-end
+             headless CMS use case.
+    Type: Normal
+    Technique: Critical path, user journey
+    User flow: API creation -> Admin login -> Listing check -> Edit view preview
+    Prerequisites:
+    - Django live_server is running
+    - DRF CRUD endpoint is available at /api/reusable-blocks/
+    Test data:
+    - ReusableBlock with rich_text (created via API)
+    - ReusableBlock with raw_html (created via API)
+    Steps:
+    1. Create a rich_text block via DRF API
+    2. Create a raw_html block via DRF API
+    3. Navigate to the snippet listing page while logged in to Wagtail admin
+    4. Verify both blocks appear in the listing
+    5. Open the rich_text block edit page and check the preview content
+    6. Open the raw_html block edit page and check the preview content
+    Expected results:
+    - Both blocks appear in the listing
+    - rich_text preview shows the paragraph text
+    - raw_html preview shows the custom HTML
+    """
+    page = authenticated_page
+    base_url = live_server.url
+
+    # --- Step 1: Create rich_text block via API ---
+    rich_block = _create_block_via_api(
+        api_session,
+        base_url,
+        name="E2E Rich Text Block",
+        slug="e2e-rich-text",
+        content=[
+            {
+                "type": "rich_text",
+                "value": "<p>Hello from the API</p>",
+            }
+        ],
+    )
+    rich_block_id = rich_block["id"]
+
+    # --- Step 2: Create raw_html block via API ---
+    raw_block = _create_block_via_api(
+        api_session,
+        base_url,
+        name="E2E Raw HTML Block",
+        slug="e2e-raw-html",
+        content=[
+            {
+                "type": "raw_html",
+                "value": (
+                    '<div class="hero-banner">'
+                    "<h1>Welcome</h1>"
+                    "<p>Custom HTML content</p>"
+                    "</div>"
+                ),
+            }
+        ],
+    )
+    raw_block_id = raw_block["id"]
+
+    # --- Step 3: Navigate to snippet listing ---
+    listing_url = f"{base_url}/snippets/wagtail_reusable_blocks/reusableblock/"
+    page.goto(listing_url)
+    page.wait_for_load_state("networkidle")
+
+    # --- Step 4: Both blocks appear in the listing ---
+    expect(page.get_by_role("link", name="E2E Rich Text Block")).to_be_visible(
+        timeout=10000
+    )
+    expect(page.get_by_role("link", name="E2E Raw HTML Block")).to_be_visible(
+        timeout=10000
+    )
+
+    # --- Step 5: Open rich_text block edit and check preview ---
+    edit_url = (
+        f"{base_url}/snippets/wagtail_reusable_blocks/"
+        f"reusableblock/edit/{rich_block_id}/"
+    )
+    page.goto(edit_url)
+    page.wait_for_load_state("networkidle")
+
+    preview_button = page.locator(
+        "button:has-text('Preview'), [data-side-panel-toggle='preview']"
+    ).first
+    expect(preview_button).to_be_visible(timeout=10000)
+    preview_button.click()
+
+    preview_frame = page.frame_locator("[data-side-panel='preview'] iframe[src]")
+    expect(preview_frame.locator("body")).to_contain_text(
+        "Hello from the API", timeout=15000
+    )
+
+    # --- Step 6: Open raw_html block edit and check preview ---
+    edit_url = (
+        f"{base_url}/snippets/wagtail_reusable_blocks/"
+        f"reusableblock/edit/{raw_block_id}/"
+    )
+    page.goto(edit_url)
+    page.wait_for_load_state("networkidle")
+
+    preview_button = page.locator(
+        "button:has-text('Preview'), [data-side-panel-toggle='preview']"
+    ).first
+    expect(preview_button).to_be_visible(timeout=10000)
+    preview_button.click()
+
+    preview_frame = page.frame_locator("[data-side-panel='preview'] iframe[src]")
+    expect(preview_frame.locator("body")).to_contain_text("Welcome", timeout=15000)
+    expect(preview_frame.locator("body")).to_contain_text(
+        "Custom HTML content", timeout=15000
+    )

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -1,0 +1,706 @@
+"""Integration tests for API endpoints (Issue #207).
+
+Tests Wagtail API v2 (read-only) and DRF CRUD endpoints
+using Django TestClient with real database.
+"""
+
+import pytest
+from django.test import Client
+
+from wagtail_reusable_blocks.models import ReusableBlock
+
+
+@pytest.fixture
+def api_client():
+    return Client()
+
+
+@pytest.fixture
+def live_block(db):
+    block = ReusableBlock.objects.create(
+        name="Live Block",
+        slug="live-block",
+        content=[{"type": "rich_text", "value": "<p>Live content</p>"}],
+    )
+    return block
+
+
+@pytest.fixture
+def draft_block(db):
+    block = ReusableBlock.objects.create(
+        name="Draft Block",
+        slug="draft-block",
+        content=[{"type": "rich_text", "value": "<p>Draft content</p>"}],
+    )
+    block.live = False
+    block.save(update_fields=["live"])
+    return block
+
+
+class TestWagtailAPIv2List:
+    """Wagtail API v2 list endpoint tests."""
+
+    @pytest.mark.django_db
+    def test_list_returns_only_live_blocks(self, api_client, live_block, draft_block):
+        """GET /api/v2/reusable-blocks/ returns only live=True blocks.
+
+        Purpose: Verify that the Wagtail API v2 list endpoint returns only
+                 published blocks, ensuring draft blocks are not leaked via
+                 the public API.
+        Type: Normal
+        Technique: API endpoint
+        Integration: GET /api/v2/reusable-blocks/ -> ReusableBlockAPIViewSet -> Database
+        Test data:
+        - 1 block with live=True
+        - 1 block with live=False
+        Scenario:
+        1. Create one live block and one draft block
+        2. Call GET /api/v2/reusable-blocks/
+        3. Verify that response is 200 and contains only the live block
+        """
+        response = api_client.get("/api/v2/reusable-blocks/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["meta"]["total_count"] == 1
+        assert len(data["items"]) == 1
+        assert data["items"][0]["name"] == "Live Block"
+
+
+class TestWagtailAPIv2Detail:
+    """Wagtail API v2 detail endpoint tests."""
+
+    @pytest.mark.django_db
+    def test_detail_returns_live_block(self, api_client, live_block):
+        """GET /api/v2/reusable-blocks/<id>/ returns detail of a live block.
+
+        Purpose: Verify that the Wagtail API v2 detail endpoint returns all
+                 fields for a published block.
+        Type: Normal
+        Technique: API endpoint
+        Integration: GET /api/v2/reusable-blocks/<id>/ -> ReusableBlockAPIViewSet -> Database
+        Test data:
+        - 1 block with live=True
+        Scenario:
+        1. Create a live block
+        2. Call GET /api/v2/reusable-blocks/<id>/
+        3. Verify that response is 200 and contains expected fields
+        """
+        response = api_client.get(f"/api/v2/reusable-blocks/{live_block.pk}/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Live Block"
+        assert data["slug"] == "live-block"
+        assert data["live"] is True
+
+    @pytest.mark.django_db
+    def test_detail_draft_block_returns_404(self, api_client, draft_block):
+        """GET /api/v2/reusable-blocks/<id>/ returns 404 for live=False blocks.
+
+        Purpose: Verify that unpublished blocks cannot be accessed via the
+                 public API, ensuring content publication control.
+        Type: Error
+        Technique: API endpoint
+        Integration: GET /api/v2/reusable-blocks/<id>/ -> ReusableBlockAPIViewSet -> Database
+        Test data:
+        - 1 block with live=False (default state)
+        Scenario:
+        1. Create a draft block
+        2. Call GET /api/v2/reusable-blocks/<id>/
+        3. Verify that response is 404
+        """
+        response = api_client.get(f"/api/v2/reusable-blocks/{draft_block.pk}/")
+
+        assert response.status_code == 404
+
+
+class TestWagtailAPIv2ResponseFields:
+    """Wagtail API v2 response field tests."""
+
+    @pytest.mark.django_db
+    def test_listing_contains_expected_fields(self, api_client, live_block):
+        """GET /api/v2/reusable-blocks/ response contains expected fields.
+
+        Purpose: Verify that the list endpoint response structure matches
+                 the API contract.
+        Type: Normal
+        Technique: API endpoint
+        Integration: GET /api/v2/reusable-blocks/ -> ReusableBlockAPIViewSet -> Serializer
+        Test data:
+        - 1 block with live=True
+        Scenario:
+        1. Call GET /api/v2/reusable-blocks/
+        2. Verify each item contains name, slug, live, and updated_at
+        """
+        response = api_client.get("/api/v2/reusable-blocks/")
+
+        assert response.status_code == 200
+        data = response.json()
+        item = data["items"][0]
+        assert "name" in item
+        assert "slug" in item
+        assert "live" in item
+        assert "updated_at" in item
+
+    @pytest.mark.django_db
+    def test_detail_contains_all_body_fields(self, api_client, live_block):
+        """GET /api/v2/reusable-blocks/<id>/ response contains all body_fields.
+
+        Purpose: Verify that the detail endpoint response includes content,
+                 created_at, and other body_fields.
+        Type: Normal
+        Technique: API endpoint
+        Integration: GET /api/v2/reusable-blocks/<id>/ -> ReusableBlockAPIViewSet -> Serializer
+        Test data:
+        - 1 block with live=True
+        Scenario:
+        1. Call GET /api/v2/reusable-blocks/<id>/
+        2. Verify response contains name, slug, content, live, created_at, and updated_at
+        """
+        response = api_client.get(f"/api/v2/reusable-blocks/{live_block.pk}/")
+
+        assert response.status_code == 200
+        data = response.json()
+        for field in ["name", "slug", "content", "live", "created_at", "updated_at"]:
+            assert field in data, f"Field '{field}' missing from detail response"
+
+
+class TestDRFListEndpoint:
+    """DRF CRUD list endpoint tests."""
+
+    @pytest.mark.django_db
+    def test_authenticated_user_can_list_blocks(
+        self, api_client, admin_user, live_block
+    ):
+        """GET /api/reusable-blocks/ returns a list for authenticated users.
+
+        Purpose: Verify that an authenticated user can retrieve a block list
+                 via the DRF CRUD endpoint.
+        Type: Normal
+        Technique: API endpoint, authentication/authorization
+        Integration: GET /api/reusable-blocks/ -> ReusableBlockModelViewSet -> Database
+        Test data:
+        - Admin user
+        - 1 block with live=True
+        Scenario:
+        1. Log in as admin
+        2. Call GET /api/reusable-blocks/
+        3. Verify response is 200 and contains a block list
+        """
+        api_client.force_login(admin_user)
+
+        response = api_client.get("/api/reusable-blocks/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) >= 1
+
+    @pytest.mark.django_db
+    def test_unauthenticated_user_gets_forbidden(self, api_client, live_block):
+        """GET /api/reusable-blocks/ returns 403 for unauthenticated users.
+
+        Purpose: Verify that unauthenticated users cannot access the DRF CRUD
+                 endpoint, ensuring authentication/authorization requirements.
+        Type: Error
+        Technique: Authentication/authorization
+        Integration: GET /api/reusable-blocks/ -> IsAuthenticated -> 403
+        Test data:
+        - 1 block (accessed without authentication)
+        Scenario:
+        1. Call GET /api/reusable-blocks/ without login
+        2. Verify response is 403
+        """
+        response = api_client.get("/api/reusable-blocks/")
+
+        assert response.status_code == 403
+
+
+class TestDRFCreateEndpoint:
+    """DRF CRUD create endpoint tests."""
+
+    @pytest.mark.django_db
+    def test_create_block_with_name_and_content(self, api_client, admin_user):
+        """POST /api/reusable-blocks/ creates a block.
+
+        Purpose: Verify that an authenticated user can create a block with
+                 name and content JSON, and it is saved to the database.
+        Type: Normal
+        Technique: API endpoint
+        Integration: POST /api/reusable-blocks/ -> ReusableBlockSerializer -> Database
+        Test data:
+        - Admin user
+        - name: "API Block", content: StreamField JSON
+        Scenario:
+        1. Log in as admin
+        2. POST to /api/reusable-blocks/ with name and content
+        3. Verify response is 201 and returns created block data
+        4. Verify block is saved in the database
+        """
+        api_client.force_login(admin_user)
+
+        response = api_client.post(
+            "/api/reusable-blocks/",
+            data={
+                "name": "API Block",
+                "content": [{"type": "rich_text", "value": "<p>API content</p>"}],
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "API Block"
+        assert data["id"] is not None
+        assert ReusableBlock.objects.filter(name="API Block").exists()
+
+    @pytest.mark.django_db
+    def test_create_block_auto_generates_slug(self, api_client, admin_user):
+        """POST /api/reusable-blocks/ auto-generates slug from name.
+
+        Purpose: Verify that slug is automatically generated when only name
+                 is provided during block creation.
+        Type: Normal
+        Technique: API endpoint
+        Integration: POST /api/reusable-blocks/ -> ReusableBlockSerializer.validate -> Database
+        Test data:
+        - Admin user
+        - name: "Auto Slug Block" (slug not specified)
+        Scenario:
+        1. Log in as admin
+        2. POST to /api/reusable-blocks/ without slug
+        3. Verify the slug is auto-generated from the name
+        """
+        api_client.force_login(admin_user)
+
+        response = api_client.post(
+            "/api/reusable-blocks/",
+            data={"name": "Auto Slug Block", "content": []},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["slug"] == "auto-slug-block"
+
+    @pytest.mark.django_db
+    def test_create_block_slug_duplicate_returns_400(self, api_client, admin_user):
+        """POST /api/reusable-blocks/ returns 400 for duplicate slug.
+
+        Purpose: Verify that duplicate slug returns a validation error (400)
+                 instead of IntegrityError, providing proper error messages
+                 to API consumers.
+        Type: Error
+        Technique: API endpoint
+        Integration: POST /api/reusable-blocks/ -> ReusableBlockSerializer.validate -> 400
+        Test data:
+        - Admin user
+        - Existing block with slug: "existing-block"
+        - New block creation attempt with same slug
+        Scenario:
+        1. Create a block with slug="existing-block"
+        2. POST to /api/reusable-blocks/ with the same slug
+        3. Verify response is 400 with slug error message
+        """
+        ReusableBlock.objects.create(name="Existing Block", slug="existing-block")
+        api_client.force_login(admin_user)
+
+        response = api_client.post(
+            "/api/reusable-blocks/",
+            data={"name": "New Block", "slug": "existing-block", "content": []},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert "slug" in data
+
+    @pytest.mark.django_db
+    def test_create_block_empty_name_returns_400(self, api_client, admin_user):
+        """POST /api/reusable-blocks/ returns 400 for empty name.
+
+        Purpose: Verify that a validation error is returned when name is empty.
+        Type: Error
+        Technique: API endpoint
+        Integration: POST /api/reusable-blocks/ -> ReusableBlockSerializer -> 400
+        Test data:
+        - Admin user
+        - name: "" (empty string)
+        Scenario:
+        1. Log in as admin
+        2. POST to /api/reusable-blocks/ with empty name
+        3. Verify response is 400
+        """
+        api_client.force_login(admin_user)
+
+        response = api_client.post(
+            "/api/reusable-blocks/",
+            data={"name": "", "content": []},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+
+    @pytest.mark.django_db
+    def test_create_duplicate_name_blocks_returns_slug_error(
+        self, api_client, admin_user
+    ):
+        """Creating two blocks with the same name returns slug duplicate error (400, not IntegrityError).
+
+        Purpose: Verify that when creating two blocks with the same name,
+                 auto-generated slug duplication returns 400 instead of IntegrityError.
+        Type: Error
+        Technique: API endpoint
+        Integration: POST /api/reusable-blocks/ -> ReusableBlockSerializer.validate -> 400
+        Test data:
+        - Admin user
+        - Existing block with name: "Same Name"
+        - New block creation attempt with same name
+        Scenario:
+        1. Create a block with name="Same Name" via API
+        2. POST to /api/reusable-blocks/ with the same name again
+        3. Verify response is 400 (not IntegrityError)
+        """
+        api_client.force_login(admin_user)
+
+        response1 = api_client.post(
+            "/api/reusable-blocks/",
+            data={"name": "Same Name", "content": []},
+            content_type="application/json",
+        )
+        assert response1.status_code == 201
+
+        response2 = api_client.post(
+            "/api/reusable-blocks/",
+            data={"name": "Same Name", "content": []},
+            content_type="application/json",
+        )
+        assert response2.status_code == 400
+
+    @pytest.mark.django_db
+    def test_create_block_with_streamfield_json_content(self, api_client, admin_user):
+        """StreamField JSON data is correctly saved when submitted.
+
+        Purpose: Verify that StreamField JSON format content is correctly
+                 saved and retrievable.
+        Type: Normal
+        Technique: API endpoint
+        Integration: POST /api/reusable-blocks/ -> ReusableBlockSerializer -> StreamField -> Database
+        Test data:
+        - Admin user
+        - StreamField JSON with multiple block types
+        Scenario:
+        1. Log in as admin
+        2. POST to /api/reusable-blocks/ with StreamField JSON content
+        3. Verify response is 201
+        4. Verify content is saved in the database
+        """
+        api_client.force_login(admin_user)
+
+        content_data = [
+            {"type": "rich_text", "value": "<p>First paragraph</p>"},
+            {"type": "raw_html", "value": "<div class='custom'>Custom HTML</div>"},
+        ]
+
+        response = api_client.post(
+            "/api/reusable-blocks/",
+            data={"name": "StreamField Block", "content": content_data},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 201
+        block = ReusableBlock.objects.get(slug="streamfield-block")
+        assert len(block.content) == 2
+
+
+class TestDRFDetailEndpoint:
+    """DRF CRUD detail endpoint tests."""
+
+    @pytest.mark.django_db
+    def test_retrieve_block_by_id(self, api_client, admin_user, live_block):
+        """GET /api/reusable-blocks/<id>/ retrieves a single block.
+
+        Purpose: Verify that a block detail can be retrieved by ID.
+        Type: Normal
+        Technique: API endpoint
+        Integration: GET /api/reusable-blocks/<id>/ -> ReusableBlockModelViewSet -> Database
+        Test data:
+        - Admin user
+        - 1 block with live=True
+        Scenario:
+        1. Log in as admin
+        2. Call GET /api/reusable-blocks/<id>/
+        3. Verify response is 200 and returns expected block data
+        """
+        api_client.force_login(admin_user)
+
+        response = api_client.get(f"/api/reusable-blocks/{live_block.pk}/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Live Block"
+        assert data["slug"] == "live-block"
+        assert data["id"] == live_block.pk
+
+
+class TestDRFUpdateEndpoint:
+    """DRF CRUD update endpoint tests."""
+
+    @pytest.mark.django_db
+    def test_put_updates_all_fields(self, api_client, admin_user, live_block):
+        """PUT /api/reusable-blocks/<id>/ updates all fields.
+
+        Purpose: Verify that a PUT request updates all fields and the
+                 changes are reflected in the database.
+        Type: Normal
+        Technique: API endpoint
+        Integration: PUT /api/reusable-blocks/<id>/ -> ReusableBlockSerializer -> Database
+        Test data:
+        - Admin user
+        - Existing live block
+        Scenario:
+        1. Log in as admin
+        2. PUT to /api/reusable-blocks/<id>/ with all fields
+        3. Verify response is 200 and returns updated data
+        4. Verify the database block is updated
+        """
+        api_client.force_login(admin_user)
+
+        response = api_client.put(
+            f"/api/reusable-blocks/{live_block.pk}/",
+            data={
+                "name": "Updated Block",
+                "slug": "updated-block",
+                "content": [{"type": "rich_text", "value": "<p>Updated</p>"}],
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Updated Block"
+        assert data["slug"] == "updated-block"
+
+        live_block.refresh_from_db()
+        assert live_block.name == "Updated Block"
+
+    @pytest.mark.django_db
+    def test_patch_partial_update(self, api_client, admin_user, live_block):
+        """PATCH /api/reusable-blocks/<id>/ performs partial update.
+
+        Purpose: Verify that a PATCH request updates only specified fields
+                 while leaving other fields unchanged.
+        Type: Normal
+        Technique: API endpoint
+        Integration: PATCH /api/reusable-blocks/<id>/ -> ReusableBlockSerializer -> Database
+        Test data:
+        - Admin user
+        - Existing live block
+        Scenario:
+        1. Log in as admin
+        2. PATCH to /api/reusable-blocks/<id>/ with name only
+        3. Verify name is updated and slug remains unchanged
+        """
+        api_client.force_login(admin_user)
+
+        response = api_client.patch(
+            f"/api/reusable-blocks/{live_block.pk}/",
+            data={"name": "Patched Block"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Patched Block"
+        assert data["slug"] == "live-block"
+
+    @pytest.mark.django_db
+    def test_put_nonexistent_id_returns_404(self, api_client, admin_user):
+        """PUT /api/reusable-blocks/<id>/ returns 404 for non-existent ID.
+
+        Purpose: Verify that a PUT request for a non-existent ID returns 404.
+        Type: Error
+        Technique: API endpoint
+        Integration: PUT /api/reusable-blocks/<id>/ -> 404
+        Test data:
+        - Admin user
+        - Non-existent ID: 99999
+        Scenario:
+        1. Log in as admin
+        2. PUT to /api/reusable-blocks/99999/
+        3. Verify response is 404
+        """
+        api_client.force_login(admin_user)
+
+        response = api_client.put(
+            "/api/reusable-blocks/99999/",
+            data={
+                "name": "Ghost Block",
+                "slug": "ghost-block",
+                "content": [],
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == 404
+
+
+class TestDRFDeleteEndpoint:
+    """DRF CRUD delete endpoint tests."""
+
+    @pytest.mark.django_db
+    def test_delete_removes_block(self, api_client, admin_user, live_block):
+        """DELETE /api/reusable-blocks/<id>/ deletes the block.
+
+        Purpose: Verify that a DELETE request removes the block from the database.
+        Type: Normal
+        Technique: API endpoint
+        Integration: DELETE /api/reusable-blocks/<id>/ -> ReusableBlockModelViewSet -> Database
+        Test data:
+        - Admin user
+        - Existing live block
+        Scenario:
+        1. Log in as admin
+        2. DELETE /api/reusable-blocks/<id>/
+        3. Verify response is 204
+        4. Verify block is removed from the database
+        """
+        api_client.force_login(admin_user)
+        block_pk = live_block.pk
+
+        response = api_client.delete(f"/api/reusable-blocks/{block_pk}/")
+
+        assert response.status_code == 204
+        assert not ReusableBlock.objects.filter(pk=block_pk).exists()
+
+
+class TestDRFFilterEndpoints:
+    """DRF CRUD filter endpoint tests."""
+
+    @pytest.mark.django_db
+    def test_filter_by_slug(self, api_client, admin_user, live_block, draft_block):
+        """GET /api/reusable-blocks/?slug=xxx filters by slug.
+
+        Purpose: Verify that blocks can be filtered by the slug parameter.
+        Type: Normal
+        Technique: API endpoint
+        Integration: GET /api/reusable-blocks/?slug=xxx -> get_queryset -> Database
+        Test data:
+        - Admin user
+        - Multiple blocks
+        Scenario:
+        1. Log in as admin
+        2. Call GET /api/reusable-blocks/?slug=live-block
+        3. Verify only the block with slug=live-block is returned
+        """
+        api_client.force_login(admin_user)
+
+        response = api_client.get("/api/reusable-blocks/?slug=live-block")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["slug"] == "live-block"
+
+    @pytest.mark.django_db
+    def test_filter_by_live(self, api_client, admin_user, live_block, draft_block):
+        """GET /api/reusable-blocks/?live=true filters by live status.
+
+        Purpose: Verify that blocks can be filtered by the live parameter.
+        Type: Normal
+        Technique: API endpoint
+        Integration: GET /api/reusable-blocks/?live=true -> get_queryset -> Database
+        Test data:
+        - Admin user
+        - 1 block with live=True, 1 block with live=False
+        Scenario:
+        1. Log in as admin
+        2. Call GET /api/reusable-blocks/?live=true
+        3. Verify only the live block is returned
+        """
+        api_client.force_login(admin_user)
+
+        response = api_client.get("/api/reusable-blocks/?live=true")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Live Block"
+
+    @pytest.mark.django_db
+    def test_search_by_name(self, api_client, admin_user):
+        """GET /api/reusable-blocks/?search=xxx searches by name.
+
+        Purpose: Verify that blocks can be searched by the search parameter.
+        Type: Normal
+        Technique: API endpoint
+        Integration: GET /api/reusable-blocks/?search=xxx -> get_queryset -> Database
+        Test data:
+        - Admin user
+        - 3 blocks with different names
+        Scenario:
+        1. Create 3 blocks with different names
+        2. Log in as admin
+        3. Call GET /api/reusable-blocks/?search=header
+        4. Verify only blocks containing "header" in name are returned
+        """
+        ReusableBlock.objects.create(name="Header Block", slug="header-block")
+        ReusableBlock.objects.create(name="Footer Block", slug="footer-block")
+        ReusableBlock.objects.create(name="Main Header", slug="main-header")
+        api_client.force_login(admin_user)
+
+        response = api_client.get("/api/reusable-blocks/?search=header")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        names = {item["name"] for item in data}
+        assert names == {"Header Block", "Main Header"}
+
+
+class TestDRFCircularReferenceValidation:
+    """DRF CRUD circular reference validation tests."""
+
+    @pytest.mark.django_db
+    def test_self_referencing_block_returns_400(self, api_client, admin_user):
+        """PUT /api/reusable-blocks/<id>/ returns 400 when block references itself.
+
+        Purpose: Verify that updating a block's content to reference itself
+                 via reusable_block type triggers a validation error (400),
+                 ensuring circular reference protection at the API level.
+        Type: Error
+        Technique: API endpoint
+        Integration: PUT /api/reusable-blocks/<id>/ -> ReusableBlockSerializer -> full_clean -> 400
+        Test data:
+        - Admin user
+        - Existing block that attempts self-reference
+        Scenario:
+        1. Create a block via POST
+        2. PUT to update the block's content with a reusable_block referencing itself
+        3. Verify response is 400
+        """
+        api_client.force_login(admin_user)
+
+        create_response = api_client.post(
+            "/api/reusable-blocks/",
+            data={
+                "name": "Self Ref Block",
+                "slug": "self-ref-block",
+                "content": [{"type": "rich_text", "value": "<p>initial</p>"}],
+            },
+            content_type="application/json",
+        )
+        assert create_response.status_code == 201
+        block_id = create_response.json()["id"]
+
+        response = api_client.put(
+            f"/api/reusable-blocks/{block_id}/",
+            data={
+                "name": "Self Ref Block",
+                "slug": "self-ref-block",
+                "content": [{"type": "reusable_block", "value": block_id}],
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400

--- a/tests/test_api_unit.py
+++ b/tests/test_api_unit.py
@@ -1,0 +1,1103 @@
+"""API module unit tests for wagtail-reusable-blocks.
+
+## DT-LIVE-FILTER: live query parameter parsing
+
+| ID  | live param | expected filter value |
+|-----|-----------|----------------------|
+| DT1 | "true"    | True                 |
+| DT2 | "1"       | True                 |
+| DT3 | "yes"     | True                 |
+| DT4 | "false"   | False                |
+| DT5 | "0"       | False                |
+| DT6 | "no"      | False                |
+| DT7 | "TRUE"    | True                 |
+| DT8 | "True"    | True                 |
+
+## DT-RESOLVE-CLASSES: _resolve_classes class resolution
+
+| ID  | setting value           | expected return        |
+|-----|------------------------|------------------------|
+| DT1 | None                   | None                   |
+| DT2 | ["dotted.path.Class"]  | [<resolved Class>]     |
+| DT3 | [ClassObject]          | [ClassObject]          |
+| DT4 | ["path.A", ClassB]     | [<A>, ClassB]          |
+| DT5 | []                     | []                     |
+"""
+
+from unittest import mock
+
+import pytest
+from django.utils.text import slugify
+from rest_framework import permissions, serializers
+
+from wagtail_reusable_blocks.api.serializers import (
+    ReusableBlockSerializer,
+    StreamFieldField,
+)
+from wagtail_reusable_blocks.api.views import (
+    ReusableBlockAPIViewSet,
+    ReusableBlockModelViewSet,
+    _resolve_classes,
+)
+from wagtail_reusable_blocks.conf import DEFAULTS, get_setting
+
+
+# ---------------------------------------------------------------------------
+# conf.py - get_setting
+# ---------------------------------------------------------------------------
+class TestGetSetting:
+    """get_setting configuration resolution tests."""
+
+    def test_api_permission_classes_default(self):
+        """Verify that the default value of API_PERMISSION_CLASSES is IsAuthenticated.
+
+        Purpose: Verify that get_setting("API_PERMISSION_CLASSES") returns
+                 the IsAuthenticated path as default, ensuring the default
+                 API authorization configuration.
+        Type: Normal
+        Target: get_setting("API_PERMISSION_CLASSES")
+        Technique: Equivalence partitioning
+        Test data: No user settings (DEFAULTS only)
+        """
+        result = get_setting("API_PERMISSION_CLASSES")
+
+        assert result == ["rest_framework.permissions.IsAuthenticated"]
+
+    def test_api_authentication_classes_default_is_none(self):
+        """Verify that the default value of API_AUTHENTICATION_CLASSES is None.
+
+        Purpose: Verify that get_setting("API_AUTHENTICATION_CLASSES") returns
+                 None, ensuring DRF default authentication is used.
+        Type: Normal
+        Target: get_setting("API_AUTHENTICATION_CLASSES")
+        Technique: Equivalence partitioning
+        Test data: No user settings (DEFAULTS only)
+        """
+        result = get_setting("API_AUTHENTICATION_CLASSES")
+
+        assert result is None
+
+    @mock.patch(
+        "wagtail_reusable_blocks.conf.settings",
+    )
+    def test_user_setting_overrides_default(self, mock_settings):
+        """Verify that user settings override default values.
+
+        Purpose: Verify that providing WAGTAIL_REUSABLE_BLOCKS with custom
+                 settings overrides the defaults, ensuring customization support.
+        Type: Normal
+        Target: get_setting(key)
+        Technique: Equivalence partitioning
+        Test data: Override to AllowAny permission
+        """
+        custom_classes = ["rest_framework.permissions.AllowAny"]
+        mock_settings.WAGTAIL_REUSABLE_BLOCKS = {
+            "API_PERMISSION_CLASSES": custom_classes,
+        }
+
+        result = get_setting("API_PERMISSION_CLASSES")
+
+        assert result == custom_classes
+
+    @mock.patch(
+        "wagtail_reusable_blocks.conf.settings",
+    )
+    def test_user_setting_overrides_none_to_list(self, mock_settings):
+        """Verify that a None default can be overridden with a list.
+
+        Purpose: Verify that API_AUTHENTICATION_CLASSES default None can be
+                 overridden with a custom list, ensuring authentication
+                 customization support.
+        Type: Normal
+        Target: get_setting("API_AUTHENTICATION_CLASSES")
+        Technique: Equivalence partitioning
+        Test data: Override to TokenAuthentication
+        """
+        custom_auth = ["rest_framework.authentication.TokenAuthentication"]
+        mock_settings.WAGTAIL_REUSABLE_BLOCKS = {
+            "API_AUTHENTICATION_CLASSES": custom_auth,
+        }
+
+        result = get_setting("API_AUTHENTICATION_CLASSES")
+
+        assert result == custom_auth
+
+    def test_defaults_dict_contains_all_api_keys(self):
+        """Verify that the DEFAULTS dict contains all API-related keys.
+
+        Purpose: Verify that DEFAULTS contains API_PERMISSION_CLASSES and
+                 API_AUTHENTICATION_CLASSES, ensuring API settings coverage.
+        Type: Normal
+        Target: conf.DEFAULTS
+        Technique: Equivalence partitioning
+        Test data: DEFAULTS dict keys
+        """
+        expected_keys = {
+            "API_PERMISSION_CLASSES",
+            "API_AUTHENTICATION_CLASSES",
+        }
+
+        assert expected_keys.issubset(set(DEFAULTS.keys()))
+
+
+# ---------------------------------------------------------------------------
+# _resolve_classes
+# ---------------------------------------------------------------------------
+class TestResolveClasses:
+    """_resolve_classes class resolution tests."""
+
+    @mock.patch("wagtail_reusable_blocks.api.views.get_setting", return_value=None)
+    def test_returns_none_when_setting_is_none(self, mock_get_setting):
+        """Verify that None is returned when the setting value is None.
+
+        Purpose: Verify that _resolve_classes returns None for a None setting,
+                 ensuring fallback to DRF defaults.
+        Type: Edge case
+        Target: _resolve_classes(setting_key)
+        Technique: Equivalence partitioning (DT-RESOLVE-CLASSES DT1)
+        Test data: None setting
+        """
+        result = _resolve_classes("API_AUTHENTICATION_CLASSES")
+
+        assert result is None
+        mock_get_setting.assert_called_once_with("API_AUTHENTICATION_CLASSES")
+
+    @mock.patch("wagtail_reusable_blocks.api.views.get_setting")
+    @mock.patch("wagtail_reusable_blocks.api.views.import_string")
+    def test_resolves_string_path_to_class(self, mock_import, mock_get_setting):
+        """Verify that a string path is resolved to a class.
+
+        Purpose: Verify that _resolve_classes resolves dotted path strings
+                 to classes via import_string, ensuring class resolution
+                 from string paths.
+        Type: Normal
+        Target: _resolve_classes(setting_key)
+        Technique: Equivalence partitioning (DT-RESOLVE-CLASSES DT2)
+        Test data: IsAuthenticated string path
+        """
+        mock_get_setting.return_value = ["rest_framework.permissions.IsAuthenticated"]
+        sentinel_class = type("SentinelPermission", (), {})
+        mock_import.return_value = sentinel_class
+
+        result = _resolve_classes("API_PERMISSION_CLASSES")
+
+        assert result == [sentinel_class]
+        mock_import.assert_called_once_with(
+            "rest_framework.permissions.IsAuthenticated"
+        )
+
+    @mock.patch("wagtail_reusable_blocks.api.views.get_setting")
+    def test_passes_through_class_objects(self, mock_get_setting):
+        """Verify that direct class objects are passed through as-is.
+
+        Purpose: Verify that _resolve_classes returns class objects directly
+                 without transformation, ensuring direct class specification
+                 support.
+        Type: Normal
+        Target: _resolve_classes(setting_key)
+        Technique: Equivalence partitioning (DT-RESOLVE-CLASSES DT3)
+        Test data: IsAuthenticated class object
+        """
+        mock_get_setting.return_value = [permissions.IsAuthenticated]
+
+        result = _resolve_classes("API_PERMISSION_CLASSES")
+
+        assert result == [permissions.IsAuthenticated]
+
+    @mock.patch("wagtail_reusable_blocks.api.views.get_setting")
+    @mock.patch("wagtail_reusable_blocks.api.views.import_string")
+    def test_resolves_mixed_strings_and_classes(self, mock_import, mock_get_setting):
+        """Verify that a mixed list of strings and class objects is resolved.
+
+        Purpose: Verify that _resolve_classes correctly resolves a mixed list
+                 of string paths and class objects, ensuring compatibility
+                 with mixed specification.
+        Type: Normal
+        Target: _resolve_classes(setting_key)
+        Technique: Equivalence partitioning (DT-RESOLVE-CLASSES DT4)
+        Test data: 1 string path + 1 class object
+        """
+        resolved_class = type("ResolvedPerm", (), {})
+        mock_import.return_value = resolved_class
+        mock_get_setting.return_value = [
+            "some.module.PermA",
+            permissions.AllowAny,
+        ]
+
+        result = _resolve_classes("API_PERMISSION_CLASSES")
+
+        assert result is not None
+        assert len(result) == 2
+        assert result[0] is resolved_class
+        assert result[1] is permissions.AllowAny
+
+    @mock.patch("wagtail_reusable_blocks.api.views.get_setting", return_value=[])
+    def test_returns_empty_list_for_empty_setting(self, mock_get_setting):
+        """Verify that an empty list is returned for an empty setting.
+
+        Purpose: Verify that _resolve_classes returns an empty list for an
+                 empty setting, ensuring permission disabling support.
+        Type: Edge case
+        Target: _resolve_classes(setting_key)
+        Technique: Boundary analysis (DT-RESOLVE-CLASSES DT5)
+        Test data: Empty list
+        """
+        result = _resolve_classes("API_PERMISSION_CLASSES")
+
+        assert result == []
+
+    @mock.patch("wagtail_reusable_blocks.api.views.get_setting")
+    @mock.patch("wagtail_reusable_blocks.api.views.import_string")
+    def test_raises_import_error_for_invalid_path(self, mock_import, mock_get_setting):
+        """Verify that ImportError is raised for an invalid string path.
+
+        Purpose: Verify that _resolve_classes raises ImportError for a
+                 non-existent module path, ensuring invalid configuration
+                 detection.
+        Type: Error
+        Target: _resolve_classes(setting_key)
+        Technique: Error guessing
+        Test data: Non-existent module path
+        """
+        mock_get_setting.return_value = ["nonexistent.module.Class"]
+        mock_import.side_effect = ImportError("No module named 'nonexistent'")
+
+        with pytest.raises(ImportError, match="No module named"):
+            _resolve_classes("API_PERMISSION_CLASSES")
+
+
+# ---------------------------------------------------------------------------
+# ReusableBlockSerializer - field definitions
+# ---------------------------------------------------------------------------
+class TestReusableBlockSerializerFields:
+    """ReusableBlockSerializer field definition tests."""
+
+    def test_meta_fields_contain_expected_fields(self):
+        """Verify that Meta.fields contains all expected fields.
+
+        Purpose: Verify that ReusableBlockSerializer.Meta.fields includes
+                 all API-specified fields, ensuring response field coverage.
+        Type: Normal
+        Target: ReusableBlockSerializer.Meta.fields
+        Technique: Equivalence partitioning
+        Test data: Meta.fields attribute
+        """
+        expected = ["id", "name", "slug", "content", "live", "created_at", "updated_at"]
+
+        assert ReusableBlockSerializer.Meta.fields == expected
+
+    def test_read_only_fields_are_correct(self):
+        """Verify that read_only_fields contains id, created_at, updated_at, and live.
+
+        Purpose: Verify that ReusableBlockSerializer.Meta.read_only_fields
+                 includes auto-generated fields, preventing API write-through.
+        Type: Normal
+        Target: ReusableBlockSerializer.Meta.read_only_fields
+        Technique: Equivalence partitioning
+        Test data: Meta.read_only_fields attribute
+        """
+        expected = ["id", "created_at", "updated_at", "live"]
+
+        assert ReusableBlockSerializer.Meta.read_only_fields == expected
+
+    def test_content_field_is_stream_field_field(self):
+        """Verify that the content field is defined as StreamFieldField.
+
+        Purpose: Verify that the content field uses StreamFieldField for
+                 StreamValue-to-JSON conversion, ensuring StreamField data
+                 read/write support.
+        Type: Normal
+        Target: ReusableBlockSerializer.content
+        Technique: Equivalence partitioning
+        Test data: content field class
+        """
+        serializer = ReusableBlockSerializer()
+
+        assert isinstance(serializer.fields["content"], StreamFieldField)
+
+    def test_content_field_not_required(self):
+        """Verify that the content field is not required.
+
+        Purpose: Verify that the content field is defined with required=False,
+                 ensuring block creation with empty content is supported.
+        Type: Normal
+        Target: ReusableBlockSerializer.content
+        Technique: Equivalence partitioning
+        Test data: content field required attribute
+        """
+        serializer = ReusableBlockSerializer()
+
+        assert serializer.fields["content"].required is False
+
+
+# ---------------------------------------------------------------------------
+# ReusableBlockSerializer - validate_slug
+# ---------------------------------------------------------------------------
+class TestReusableBlockSerializerValidateSlug:
+    """ReusableBlockSerializer.validate_slug slug uniqueness tests."""
+
+    @mock.patch("wagtail_reusable_blocks.api.serializers.ReusableBlock.objects")
+    def test_unique_slug_passes_validation(self, mock_objects):
+        """Verify that a unique slug passes validation.
+
+        Purpose: Verify that validate_slug accepts a non-duplicate slug,
+                 ensuring unique slug acceptance.
+        Type: Normal
+        Target: ReusableBlockSerializer.validate_slug(value)
+        Technique: Equivalence partitioning
+        Test data: slug "new-block" not in database
+        """
+        mock_qs = mock.MagicMock()
+        mock_qs.exists.return_value = False
+        mock_objects.filter.return_value = mock_qs
+        serializer = ReusableBlockSerializer()
+
+        result = serializer.validate_slug("new-block")
+
+        assert result == "new-block"
+        mock_objects.filter.assert_called_once_with(slug="new-block")
+
+    @mock.patch("wagtail_reusable_blocks.api.serializers.ReusableBlock.objects")
+    def test_duplicate_slug_raises_error_on_create(self, mock_objects):
+        """Verify that a duplicate slug raises ValidationError on create.
+
+        Purpose: Verify that validate_slug raises ValidationError for a
+                 duplicate slug, ensuring slug uniqueness constraint.
+        Type: Error
+        Target: ReusableBlockSerializer.validate_slug(value)
+        Technique: Equivalence partitioning
+        Test data: slug "existing-block" already in database
+        """
+        mock_qs = mock.MagicMock()
+        mock_qs.exists.return_value = True
+        mock_objects.filter.return_value = mock_qs
+        serializer = ReusableBlockSerializer()
+
+        with pytest.raises(serializers.ValidationError, match="already exists"):
+            serializer.validate_slug("existing-block")
+
+    @mock.patch("wagtail_reusable_blocks.api.serializers.ReusableBlock.objects")
+    def test_update_excludes_own_pk_from_uniqueness_check(self, mock_objects):
+        """Verify that the own PK is excluded from uniqueness check on update.
+
+        Purpose: Verify that validate_slug excludes the current instance's PK
+                 from the uniqueness check, ensuring self-exclusion on update.
+        Type: Normal
+        Target: ReusableBlockSerializer.validate_slug(value)
+        Technique: Equivalence partitioning
+        Test data: Instance with pk=42 retaining its own slug
+        """
+        mock_instance = mock.Mock(pk=42)
+        mock_qs = mock.MagicMock()
+        mock_qs.exclude.return_value = mock_qs
+        mock_qs.exists.return_value = False
+        mock_objects.filter.return_value = mock_qs
+        serializer = ReusableBlockSerializer()
+        serializer.instance = mock_instance
+
+        result = serializer.validate_slug("my-block")
+
+        assert result == "my-block"
+        mock_qs.exclude.assert_called_once_with(pk=42)
+
+    @mock.patch("wagtail_reusable_blocks.api.serializers.ReusableBlock.objects")
+    def test_update_detects_duplicate_slug_from_other_instance(self, mock_objects):
+        """Verify that slug duplication with another instance is detected on update.
+
+        Purpose: Verify that validate_slug detects slug duplication with
+                 another instance during update, raising ValidationError.
+        Type: Error
+        Target: ReusableBlockSerializer.validate_slug(value)
+        Technique: Equivalence partitioning
+        Test data: Instance with pk=42 attempting to use another instance's slug
+        """
+        mock_instance = mock.Mock(pk=42)
+        mock_qs = mock.MagicMock()
+        mock_qs.exclude.return_value = mock_qs
+        mock_qs.exists.return_value = True
+        mock_objects.filter.return_value = mock_qs
+        serializer = ReusableBlockSerializer()
+        serializer.instance = mock_instance
+
+        with pytest.raises(serializers.ValidationError, match="already exists"):
+            serializer.validate_slug("taken-slug")
+
+
+# ---------------------------------------------------------------------------
+# ReusableBlockSerializer - validate (auto-slug generation)
+# ---------------------------------------------------------------------------
+class TestReusableBlockSerializerValidate:
+    """ReusableBlockSerializer.validate auto-slug generation tests."""
+
+    @mock.patch("wagtail_reusable_blocks.api.serializers.ReusableBlock.objects")
+    def test_auto_generates_slug_from_name_when_slug_is_empty(self, mock_objects):
+        """Verify that slug is auto-generated from name when slug is empty.
+
+        Purpose: Verify that validate generates a slugified value from name
+                 when slug is empty, ensuring auto-slug generation.
+        Type: Normal
+        Target: ReusableBlockSerializer.validate(attrs)
+        Technique: Equivalence partitioning
+        Test data: Empty slug, name="My New Block"
+        """
+        mock_qs = mock.MagicMock()
+        mock_qs.exists.return_value = False
+        mock_objects.filter.return_value = mock_qs
+        serializer = ReusableBlockSerializer()
+        attrs = {"name": "My New Block", "slug": ""}
+
+        result = serializer.validate(attrs)
+
+        assert result["slug"] == slugify("My New Block")
+        assert result["slug"] == "my-new-block"
+
+    @mock.patch("wagtail_reusable_blocks.api.serializers.ReusableBlock.objects")
+    def test_auto_generates_slug_when_slug_not_provided(self, mock_objects):
+        """Verify that slug is auto-generated when slug key is not present.
+
+        Purpose: Verify that validate generates a slugified value when the
+                 slug key is absent, ensuring auto-generation when slug
+                 is omitted.
+        Type: Normal
+        Target: ReusableBlockSerializer.validate(attrs)
+        Technique: Equivalence partitioning
+        Test data: No slug key, name="Test Block"
+        """
+        mock_qs = mock.MagicMock()
+        mock_qs.exists.return_value = False
+        mock_objects.filter.return_value = mock_qs
+        serializer = ReusableBlockSerializer()
+        attrs = {"name": "Test Block"}
+
+        result = serializer.validate(attrs)
+
+        assert result["slug"] == "test-block"
+
+    @mock.patch("wagtail_reusable_blocks.api.serializers.ReusableBlock.objects")
+    def test_explicit_slug_is_preserved(self, mock_objects):
+        """Verify that an explicitly specified slug is preserved.
+
+        Purpose: Verify that validate preserves the explicitly specified slug,
+                 ensuring explicit slug takes priority.
+        Type: Normal
+        Target: ReusableBlockSerializer.validate(attrs)
+        Technique: Equivalence partitioning
+        Test data: slug="custom-slug" explicitly specified
+        """
+        mock_qs = mock.MagicMock()
+        mock_qs.exists.return_value = False
+        mock_objects.filter.return_value = mock_qs
+        serializer = ReusableBlockSerializer()
+        attrs = {"name": "My Block", "slug": "custom-slug"}
+
+        result = serializer.validate(attrs)
+
+        assert result["slug"] == "custom-slug"
+
+    @mock.patch("wagtail_reusable_blocks.api.serializers.ReusableBlock.objects")
+    def test_auto_generated_slug_uniqueness_check(self, mock_objects):
+        """Verify that ValidationError is raised when auto-generated slug already exists.
+
+        Purpose: Verify that validate raises ValidationError when the auto-generated
+                 slug duplicates an existing one, ensuring auto-generated slug
+                 uniqueness check.
+        Type: Error
+        Target: ReusableBlockSerializer.validate(attrs)
+        Technique: Error guessing
+        Test data: Auto-generated slug "my-block" already exists in database
+        """
+        mock_qs = mock.MagicMock()
+        mock_qs.exists.return_value = True
+        mock_objects.filter.return_value = mock_qs
+        serializer = ReusableBlockSerializer()
+        attrs = {"name": "My Block"}
+
+        with pytest.raises(serializers.ValidationError) as exc_info:
+            serializer.validate(attrs)
+
+        assert "slug" in exc_info.value.detail
+
+    @mock.patch("wagtail_reusable_blocks.api.serializers.ReusableBlock.objects")
+    def test_auto_generated_slug_excludes_self_on_update(self, mock_objects):
+        """Verify that the own PK is excluded from auto-generated slug uniqueness check on update.
+
+        Purpose: Verify that validate excludes the current instance's PK
+                 from the auto-generated slug uniqueness check during update.
+        Type: Normal
+        Target: ReusableBlockSerializer.validate(attrs)
+        Technique: Equivalence partitioning
+        Test data: Instance with pk=10, auto-generated slug on update
+        """
+        mock_instance = mock.Mock(pk=10)
+        mock_qs = mock.MagicMock()
+        mock_qs.exclude.return_value = mock_qs
+        mock_qs.exists.return_value = False
+        mock_objects.filter.return_value = mock_qs
+        serializer = ReusableBlockSerializer()
+        serializer.instance = mock_instance
+        attrs = {"name": "Updated Block", "slug": ""}
+
+        result = serializer.validate(attrs)
+
+        assert result["slug"] == "updated-block"
+        mock_qs.exclude.assert_called_once_with(pk=10)
+
+    @mock.patch("wagtail_reusable_blocks.api.serializers.ReusableBlock.objects")
+    def test_no_slug_no_name_does_not_generate_slug(self, mock_objects):
+        """Verify that slug is not generated when neither name nor slug is provided.
+
+        Purpose: Verify that validate does not generate a slug when both name
+                 and slug are absent, ensuring no slug is added without a name.
+        Type: Edge case
+        Target: ReusableBlockSerializer.validate(attrs)
+        Technique: Boundary analysis
+        Test data: Neither name nor slug provided
+        """
+        serializer = ReusableBlockSerializer()
+        attrs = {"content": []}
+
+        result = serializer.validate(attrs)
+
+        assert "slug" not in result or not result.get("slug")
+
+
+# ---------------------------------------------------------------------------
+# ReusableBlockSerializer - create / update
+# ---------------------------------------------------------------------------
+class TestReusableBlockSerializerCreate:
+    """ReusableBlockSerializer.create revision creation tests."""
+
+    @mock.patch("wagtail_reusable_blocks.api.serializers.ReusableBlock")
+    def test_create_saves_instance_and_revision(self, MockReusableBlock):
+        """Verify that create saves the instance and creates a revision.
+
+        Purpose: Verify that create calls full_clean, save, and save_revision
+                 in sequence, ensuring revision management on creation.
+        Type: Normal
+        Target: ReusableBlockSerializer.create(validated_data)
+        Technique: Equivalence partitioning
+        Test data: name="New Block", slug="new-block"
+        """
+        mock_instance = mock.MagicMock()
+        MockReusableBlock.return_value = mock_instance
+        serializer = ReusableBlockSerializer()
+        validated_data = {"name": "New Block", "slug": "new-block", "content": []}
+
+        result = serializer.create(validated_data)
+
+        assert result is mock_instance
+        MockReusableBlock.assert_called_once_with(**validated_data)
+        mock_instance.full_clean.assert_called_once()
+        mock_instance.save.assert_called_once()
+        mock_instance.save_revision.assert_called_once()
+
+    @mock.patch("wagtail_reusable_blocks.api.serializers.ReusableBlock")
+    def test_create_calls_methods_in_order(self, MockReusableBlock):
+        """Verify that create calls full_clean -> save -> save_revision in order.
+
+        Purpose: Verify that the method call order is full_clean -> save ->
+                 save_revision, ensuring validation before save and revision.
+        Type: Normal
+        Target: ReusableBlockSerializer.create(validated_data)
+        Technique: Equivalence partitioning
+        Test data: name="Order Test"
+        """
+        mock_instance = mock.MagicMock()
+        call_order = []
+        mock_instance.full_clean.side_effect = lambda: call_order.append("full_clean")
+        mock_instance.save.side_effect = lambda: call_order.append("save")
+        mock_instance.save_revision.side_effect = lambda: call_order.append(
+            "save_revision"
+        )
+        MockReusableBlock.return_value = mock_instance
+        serializer = ReusableBlockSerializer()
+
+        serializer.create({"name": "Order Test", "slug": "order-test"})
+
+        assert call_order == ["full_clean", "save", "save_revision"]
+
+
+class TestReusableBlockSerializerUpdate:
+    """ReusableBlockSerializer.update revision creation tests."""
+
+    def test_update_sets_attributes_and_saves_revision(self):
+        """Verify that update sets attributes, saves, and creates a revision.
+
+        Purpose: Verify that update sets attributes on the instance and then
+                 calls full_clean, save, and save_revision, ensuring revision
+                 management on update.
+        Type: Normal
+        Target: ReusableBlockSerializer.update(instance, validated_data)
+        Technique: Equivalence partitioning
+        Test data: name="Updated Name" update
+        """
+        mock_instance = mock.MagicMock()
+        serializer = ReusableBlockSerializer()
+        validated_data = {"name": "Updated Name"}
+
+        result = serializer.update(mock_instance, validated_data)
+
+        assert result is mock_instance
+        assert mock_instance.name == "Updated Name"
+        mock_instance.full_clean.assert_called_once()
+        mock_instance.save.assert_called_once()
+        mock_instance.save_revision.assert_called_once()
+
+    def test_update_sets_multiple_attributes(self):
+        """Verify that multiple attributes are set correctly on update.
+
+        Purpose: Verify that update sets all provided fields correctly,
+                 ensuring multi-field simultaneous update support.
+        Type: Normal
+        Target: ReusableBlockSerializer.update(instance, validated_data)
+        Technique: Equivalence partitioning
+        Test data: Simultaneous update of name, slug, and content
+        """
+        mock_instance = mock.MagicMock()
+        serializer = ReusableBlockSerializer()
+        content_data = [{"type": "rich_text", "value": "<p>Hello</p>"}]
+        validated_data = {
+            "name": "Updated",
+            "slug": "updated",
+            "content": content_data,
+        }
+
+        serializer.update(mock_instance, validated_data)
+
+        assert mock_instance.name == "Updated"
+        assert mock_instance.slug == "updated"
+        assert mock_instance.content == content_data
+
+    def test_update_calls_methods_in_order(self):
+        """Verify that update calls full_clean -> save -> save_revision in order.
+
+        Purpose: Verify that the method call order is full_clean -> save ->
+                 save_revision, ensuring validation before save and revision.
+        Type: Normal
+        Target: ReusableBlockSerializer.update(instance, validated_data)
+        Technique: Equivalence partitioning
+        Test data: name="Order Test"
+        """
+        mock_instance = mock.MagicMock()
+        call_order = []
+        mock_instance.full_clean.side_effect = lambda: call_order.append("full_clean")
+        mock_instance.save.side_effect = lambda: call_order.append("save")
+        mock_instance.save_revision.side_effect = lambda: call_order.append(
+            "save_revision"
+        )
+        serializer = ReusableBlockSerializer()
+
+        serializer.update(mock_instance, {"name": "Order Test"})
+
+        assert call_order == ["full_clean", "save", "save_revision"]
+
+
+# ---------------------------------------------------------------------------
+# ReusableBlockAPIViewSet
+# ---------------------------------------------------------------------------
+class TestReusableBlockAPIViewSet:
+    """ReusableBlockAPIViewSet queryset tests."""
+
+    @mock.patch("wagtail_reusable_blocks.api.views.ReusableBlock.objects")
+    def test_get_queryset_filters_live_true(self, mock_objects):
+        """Verify that get_queryset filters by live=True.
+
+        Purpose: Verify that get_queryset always returns results filtered
+                 by live=True, ensuring only published blocks are served
+                 via the public API.
+        Type: Normal
+        Target: ReusableBlockAPIViewSet.get_queryset()
+        Technique: Equivalence partitioning
+        Test data: Filter condition live=True
+        """
+        mock_qs = mock.MagicMock()
+        mock_objects.filter.return_value = mock_qs
+        viewset = ReusableBlockAPIViewSet()
+
+        result = viewset.get_queryset()
+
+        mock_objects.filter.assert_called_once_with(live=True)
+        assert result is mock_qs
+
+
+# ---------------------------------------------------------------------------
+# ReusableBlockModelViewSet - get_queryset
+# ---------------------------------------------------------------------------
+class TestReusableBlockModelViewSetGetQueryset:
+    """ReusableBlockModelViewSet.get_queryset filtering tests."""
+
+    def _make_viewset(self, query_params=None):
+        """Helper to create a viewset with mocked request."""
+        viewset = ReusableBlockModelViewSet()
+        viewset.request = mock.Mock()
+        viewset.request.query_params = query_params or {}
+        return viewset
+
+    @mock.patch("wagtail_reusable_blocks.api.views.ReusableBlock.objects")
+    def test_no_filters_returns_all(self, mock_objects):
+        """Verify that all records are returned when no filter parameters are given.
+
+        Purpose: Verify that get_queryset returns all records without filters,
+                 ensuring the default full retrieval behavior.
+        Type: Normal
+        Target: ReusableBlockModelViewSet.get_queryset()
+        Technique: Equivalence partitioning
+        Test data: Empty query_params
+        """
+        mock_qs = mock.MagicMock()
+        mock_objects.all.return_value = mock_qs
+        mock_qs.filter.return_value = mock_qs
+        viewset = self._make_viewset()
+
+        result = viewset.get_queryset()
+
+        mock_objects.all.assert_called_once()
+        assert result is mock_qs
+
+    @mock.patch("wagtail_reusable_blocks.api.views.ReusableBlock.objects")
+    def test_slug_filter(self, mock_objects):
+        """Verify that the slug parameter triggers a slug filter.
+
+        Purpose: Verify that get_queryset filters by slug=value when a slug
+                 parameter is provided.
+        Type: Normal
+        Target: ReusableBlockModelViewSet.get_queryset()
+        Technique: Equivalence partitioning
+        Test data: slug="hero-block"
+        """
+        mock_qs = mock.MagicMock()
+        mock_objects.all.return_value = mock_qs
+        mock_qs.filter.return_value = mock_qs
+        viewset = self._make_viewset({"slug": "hero-block"})
+
+        viewset.get_queryset()
+
+        mock_qs.filter.assert_any_call(slug="hero-block")
+
+    @pytest.mark.parametrize(
+        "live_param,expected_bool",
+        [
+            pytest.param("true", True, id="DT1-true"),
+            pytest.param("1", True, id="DT2-1"),
+            pytest.param("yes", True, id="DT3-yes"),
+            pytest.param("false", False, id="DT4-false"),
+            pytest.param("0", False, id="DT5-0"),
+            pytest.param("no", False, id="DT6-no"),
+            pytest.param("TRUE", True, id="DT7-TRUE-uppercase"),
+            pytest.param("True", True, id="DT8-True-titlecase"),
+        ],
+    )
+    @mock.patch("wagtail_reusable_blocks.api.views.ReusableBlock.objects")
+    def test_live_filter_parsing(self, mock_objects, live_param, expected_bool):
+        """Verify that each live parameter value is correctly parsed to a boolean.
+
+        Purpose: Verify that get_queryset correctly parses various live
+                 parameter representations to boolean values for filtering.
+        Type: Normal
+        Target: ReusableBlockModelViewSet.get_queryset()
+        Technique: Decision table (see DT-LIVE-FILTER)
+        Test data: All DT-LIVE-FILTER patterns
+        """
+        mock_qs = mock.MagicMock()
+        mock_objects.all.return_value = mock_qs
+        mock_qs.filter.return_value = mock_qs
+        viewset = self._make_viewset({"live": live_param})
+
+        viewset.get_queryset()
+
+        mock_qs.filter.assert_any_call(live=expected_bool)
+
+    @mock.patch("wagtail_reusable_blocks.api.views.ReusableBlock.objects")
+    def test_search_filter(self, mock_objects):
+        """Verify that the search parameter applies a name__icontains filter.
+
+        Purpose: Verify that get_queryset filters by name__icontains when
+                 a search parameter is provided, ensuring name search support.
+        Type: Normal
+        Target: ReusableBlockModelViewSet.get_queryset()
+        Technique: Equivalence partitioning
+        Test data: search="hero"
+        """
+        mock_qs = mock.MagicMock()
+        mock_objects.all.return_value = mock_qs
+        mock_qs.filter.return_value = mock_qs
+        viewset = self._make_viewset({"search": "hero"})
+
+        viewset.get_queryset()
+
+        mock_qs.filter.assert_any_call(name__icontains="hero")
+
+    @mock.patch("wagtail_reusable_blocks.api.views.ReusableBlock.objects")
+    def test_combined_filters(self, mock_objects):
+        """Verify that slug, live, and search filters are all applied simultaneously.
+
+        Purpose: Verify that get_queryset applies all filters in chain when
+                 slug, live, and search parameters are all provided.
+        Type: Normal
+        Target: ReusableBlockModelViewSet.get_queryset()
+        Technique: Decision table
+        Test data: slug="hero", live="true", search="hero"
+        """
+        mock_qs = mock.MagicMock()
+        mock_objects.all.return_value = mock_qs
+        mock_qs.filter.return_value = mock_qs
+        viewset = self._make_viewset({"slug": "hero", "live": "true", "search": "hero"})
+
+        viewset.get_queryset()
+
+        assert mock_qs.filter.call_count == 3
+
+    @mock.patch("wagtail_reusable_blocks.api.views.ReusableBlock.objects")
+    def test_empty_string_slug_is_not_filtered(self, mock_objects):
+        """Verify that an empty string slug does not trigger a filter.
+
+        Purpose: Verify that get_queryset ignores an empty slug parameter,
+                 ensuring empty value parameter handling.
+        Type: Edge case
+        Target: ReusableBlockModelViewSet.get_queryset()
+        Technique: Boundary analysis
+        Test data: slug=""
+        """
+        mock_qs = mock.MagicMock()
+        mock_objects.all.return_value = mock_qs
+        mock_qs.filter.return_value = mock_qs
+        viewset = self._make_viewset({"slug": ""})
+
+        viewset.get_queryset()
+
+        for call in mock_qs.filter.call_args_list:
+            assert "slug" not in call.kwargs
+
+    @mock.patch("wagtail_reusable_blocks.api.views.ReusableBlock.objects")
+    def test_empty_string_search_is_not_filtered(self, mock_objects):
+        """Verify that an empty string search does not trigger a filter.
+
+        Purpose: Verify that get_queryset ignores an empty search parameter,
+                 ensuring empty search query handling.
+        Type: Edge case
+        Target: ReusableBlockModelViewSet.get_queryset()
+        Technique: Boundary analysis
+        Test data: search=""
+        """
+        mock_qs = mock.MagicMock()
+        mock_objects.all.return_value = mock_qs
+        mock_qs.filter.return_value = mock_qs
+        viewset = self._make_viewset({"search": ""})
+
+        viewset.get_queryset()
+
+        for call in mock_qs.filter.call_args_list:
+            assert "name__icontains" not in call.kwargs
+
+
+# ---------------------------------------------------------------------------
+# ReusableBlockModelViewSet - permissions / authentication
+# ---------------------------------------------------------------------------
+class TestReusableBlockModelViewSetPermissions:
+    """ReusableBlockModelViewSet permission and authentication tests."""
+
+    @mock.patch("wagtail_reusable_blocks.api.views._resolve_classes")
+    def test_get_permissions_resolves_from_settings(self, mock_resolve):
+        """Verify that get_permissions resolves permission classes from settings.
+
+        Purpose: Verify that get_permissions calls _resolve_classes to resolve
+                 classes from settings and returns instances.
+        Type: Normal
+        Target: ReusableBlockModelViewSet.get_permissions()
+        Technique: Equivalence partitioning
+        Test data: IsAuthenticated permission
+        """
+        mock_perm_class = mock.Mock()
+        mock_perm_instance = mock.Mock()
+        mock_perm_class.return_value = mock_perm_instance
+        mock_resolve.return_value = [mock_perm_class]
+        viewset = ReusableBlockModelViewSet()
+
+        result = viewset.get_permissions()
+
+        mock_resolve.assert_called_once_with("API_PERMISSION_CLASSES")
+        assert len(result) == 1
+        assert result[0] is mock_perm_instance
+
+    @mock.patch("wagtail_reusable_blocks.api.views._resolve_classes")
+    def test_get_permissions_returns_empty_list_when_none(self, mock_resolve):
+        """Verify that an empty list is returned when the setting is None.
+
+        Purpose: Verify that get_permissions returns an empty list when
+                 _resolve_classes returns None, ensuring permission disable
+                 behavior.
+        Type: Edge case
+        Target: ReusableBlockModelViewSet.get_permissions()
+        Technique: Equivalence partitioning
+        Test data: None setting (_resolve_classes returns None)
+        """
+        mock_resolve.return_value = None
+        viewset = ReusableBlockModelViewSet()
+
+        result = viewset.get_permissions()
+
+        assert result == []
+
+    @mock.patch("wagtail_reusable_blocks.api.views._resolve_classes")
+    @mock.patch(
+        "rest_framework.viewsets.ModelViewSet.get_authenticators",
+        return_value=[mock.Mock()],
+    )
+    def test_get_authenticators_uses_drf_defaults_when_none(
+        self, mock_super_auth, mock_resolve
+    ):
+        """Verify that DRF defaults are used when authentication classes are None.
+
+        Purpose: Verify that get_authenticators uses super()'s default
+                 authentication when _resolve_classes returns None, ensuring
+                 DRF default fallback.
+        Type: Normal
+        Target: ReusableBlockModelViewSet.get_authenticators()
+        Technique: Equivalence partitioning
+        Test data: None setting (use DRF defaults)
+        """
+        mock_resolve.return_value = None
+        viewset = ReusableBlockModelViewSet()
+
+        result = viewset.get_authenticators()
+
+        mock_resolve.assert_called_once_with("API_AUTHENTICATION_CLASSES")
+        mock_super_auth.assert_called_once()
+        assert len(result) == 1
+
+    @mock.patch("wagtail_reusable_blocks.api.views._resolve_classes")
+    def test_get_authenticators_resolves_from_settings(self, mock_resolve):
+        """Verify that authentication classes are resolved from settings.
+
+        Purpose: Verify that get_authenticators resolves classes from settings
+                 via _resolve_classes and returns instances, ensuring custom
+                 authentication support.
+        Type: Normal
+        Target: ReusableBlockModelViewSet.get_authenticators()
+        Technique: Equivalence partitioning
+        Test data: Custom authentication class
+        """
+        mock_auth_class = mock.Mock()
+        mock_auth_instance = mock.Mock()
+        mock_auth_class.return_value = mock_auth_instance
+        mock_resolve.return_value = [mock_auth_class]
+        viewset = ReusableBlockModelViewSet()
+
+        result = viewset.get_authenticators()
+
+        mock_resolve.assert_called_once_with("API_AUTHENTICATION_CLASSES")
+        assert len(result) == 1
+        assert result[0] is mock_auth_instance
+
+    @mock.patch("wagtail_reusable_blocks.api.views._resolve_classes")
+    def test_get_permissions_instantiates_multiple_classes(self, mock_resolve):
+        """Verify that multiple permission classes are all instantiated.
+
+        Purpose: Verify that get_permissions instantiates all classes when
+                 multiple permission classes are configured.
+        Type: Normal
+        Target: ReusableBlockModelViewSet.get_permissions()
+        Technique: Equivalence partitioning
+        Test data: 2 permission classes
+        """
+        cls_a = mock.Mock()
+        cls_b = mock.Mock()
+        mock_resolve.return_value = [cls_a, cls_b]
+        viewset = ReusableBlockModelViewSet()
+
+        result = viewset.get_permissions()
+
+        assert len(result) == 2
+        cls_a.assert_called_once()
+        cls_b.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# ReusableBlock.api_fields
+# ---------------------------------------------------------------------------
+class TestReusableBlockApiFields:
+    """ReusableBlock.api_fields configuration tests."""
+
+    def test_api_fields_contain_expected_names(self):
+        """Verify that api_fields contains all expected field names.
+
+        Purpose: Verify that ReusableBlock.api_fields includes name, slug,
+                 content, created_at, updated_at, and live, ensuring Wagtail
+                 API v2 response field requirements.
+        Type: Normal
+        Target: ReusableBlock.api_fields
+        Technique: Equivalence partitioning
+        Test data: api_fields field name list
+        """
+        from wagtail_reusable_blocks.models import ReusableBlock
+
+        field_names = [field.name for field in ReusableBlock.api_fields]
+        expected = ["name", "slug", "content", "created_at", "updated_at", "live"]
+
+        assert field_names == expected
+
+    def test_api_fields_count(self):
+        """Verify that the api_fields count is correct.
+
+        Purpose: Verify that ReusableBlock.api_fields has exactly 6 fields,
+                 ensuring no unintended field exposure or missing fields.
+        Type: Normal
+        Target: ReusableBlock.api_fields
+        Technique: Equivalence partitioning
+        Test data: api_fields length
+        """
+        from wagtail_reusable_blocks.models import ReusableBlock
+
+        assert len(ReusableBlock.api_fields) == 6
+
+
+# ---------------------------------------------------------------------------
+# API __init__.py - public exports
+# ---------------------------------------------------------------------------
+class TestApiModuleExports:
+    """API module __init__.py public export tests."""
+
+    def test_exports_reusable_block_api_viewset(self):
+        """Verify that ReusableBlockAPIViewSet is exported from the module.
+
+        Purpose: Verify that ReusableBlockAPIViewSet can be imported from
+                 wagtail_reusable_blocks.api, ensuring public API availability.
+        Type: Normal
+        Target: wagtail_reusable_blocks.api.__all__
+        Technique: Equivalence partitioning
+        Test data: Module import
+        """
+        from wagtail_reusable_blocks.api import ReusableBlockAPIViewSet as cls
+
+        assert cls is ReusableBlockAPIViewSet
+
+    def test_exports_reusable_block_model_viewset(self):
+        """Verify that ReusableBlockModelViewSet is exported from the module.
+
+        Purpose: Verify that ReusableBlockModelViewSet can be imported from
+                 wagtail_reusable_blocks.api, ensuring public API availability.
+        Type: Normal
+        Target: wagtail_reusable_blocks.api.__all__
+        Technique: Equivalence partitioning
+        Test data: Module import
+        """
+        from wagtail_reusable_blocks.api import ReusableBlockModelViewSet as cls
+
+        assert cls is ReusableBlockModelViewSet
+
+    def test_all_contains_expected_exports(self):
+        """Verify that __all__ contains the expected exports.
+
+        Purpose: Verify that wagtail_reusable_blocks.api.__all__ includes
+                 both ViewSet classes, ensuring explicit public API definition.
+        Type: Normal
+        Target: wagtail_reusable_blocks.api.__all__
+        Technique: Equivalence partitioning
+        Test data: __all__ attribute
+        """
+        import wagtail_reusable_blocks.api as api_module
+
+        assert set(api_module.__all__) == {
+            "ReusableBlockAPIViewSet",
+            "ReusableBlockModelViewSet",
+        }

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -6,9 +6,26 @@ Minimal URL configuration for running tests.
 
 from django.contrib import admin
 from django.urls import include, path
+from rest_framework.routers import DefaultRouter
+from wagtail.api.v2.router import WagtailAPIRouter
+
+from wagtail_reusable_blocks.api import (
+    ReusableBlockAPIViewSet,
+    ReusableBlockModelViewSet,
+)
+
+# Wagtail API v2 router (read-only)
+wagtail_api_router = WagtailAPIRouter("wagtailapi")
+wagtail_api_router.register_endpoint("reusable-blocks", ReusableBlockAPIViewSet)
+
+# DRF router (CRUD)
+drf_router = DefaultRouter()
+drf_router.register("reusable-blocks", ReusableBlockModelViewSet)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/v2/", wagtail_api_router.urls),
+    path("api/", include(drf_router.urls)),
     path("", include("wagtail.admin.urls")),
     path("", include("wagtail.urls")),
 ]


### PR DESCRIPTION
## Summary

Merge develop into main for v0.8.0 release.

### Included PRs
- #208 feat: Add REST API support for ReusableBlock CRUD operations

### Key Changes
- Wagtail API v2 read-only endpoint for published ReusableBlocks
- DRF ModelViewSet for full CRUD operations (create, read, update, delete)
- Custom StreamFieldField serializer for proper StreamField JSON handling
- Configurable authentication and permission classes via settings
- Circular reference validation through API layer
- Comprehensive test suite (unit, integration, contract, E2E)