### PR TITLE
WIP: #228 Fix nested ReusableLayoutBlock slot chooser bugs

### DIFF
--- a/src/wagtail_reusable_blocks/static/wagtail_reusable_blocks/js/slot-chooser.js
+++ b/src/wagtail_reusable_blocks/static/wagtail_reusable_blocks/js/slot-chooser.js
@@ -26,64 +26,74 @@ class SlotChooserWidget {
         this.slotContentFieldId = slotContentFieldId;
         this.slots = [];
 
+        // Match only direct slot_id fields for THIS instance,
+        // preventing parent from matching nested child fields
+        const escapedPrefix = this.slotContentFieldId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        this.directSlotPattern = new RegExp(`^${escapedPrefix}-\\d+-slot_id$`);
+
         this.init();
     }
 
     init() {
-        // SnippetChooser creates a hidden input with the actual value
-        // The field ID points to the container, we need to find the hidden input
         const layoutField = document.querySelector(`input[name="${this.layoutFieldId}"]`);
         if (!layoutField) {
             return;
         }
 
-        // Listen for layout changes
         layoutField.addEventListener('change', (e) => {
             this.onLayoutChange(e.target.value);
         });
 
-        // If a layout is already selected, load its slots
         if (layoutField.value) {
             this.onLayoutChange(layoutField.value);
         }
 
-        // Use MutationObserver to watch for SlotFill blocks being added
-        // This handles when new SlotFill blocks are added to slot_content StreamField
+        // Scope the MutationObserver to the slot_content container when possible,
+        // falling back to document.body for robustness
+        let observeTarget = document.body;
+        const layoutSection = layoutField.closest('[data-contentpath="layout"]');
+        if (layoutSection && layoutSection.parentElement) {
+            const slotContentSection = layoutSection.parentElement.querySelector(
+                ':scope > [data-contentpath="slot_content"]'
+            );
+            if (slotContentSection) {
+                observeTarget = slotContentSection;
+            }
+        }
+
         const observer = new MutationObserver((mutations) => {
             let shouldUpdate = false;
 
             for (const mutation of mutations) {
                 for (const node of mutation.addedNodes) {
-                    if (node.nodeType === 1) { // Element node
-                        // Check if the added node contains slot_id input fields
-                        const hasSlotIdField = node.querySelector &&
-                            node.querySelector('input[name*="slot_id"]');
-
-                        if (hasSlotIdField) {
-                            shouldUpdate = true;
-                            break;
+                    if (node.nodeType === 1) {
+                        const candidates = node.querySelectorAll
+                            ? node.querySelectorAll('input[name$="-slot_id"]')
+                            : [];
+                        for (const input of candidates) {
+                            if (this.directSlotPattern.test(input.name)) {
+                                shouldUpdate = true;
+                                break;
+                            }
                         }
                     }
+                    if (shouldUpdate) break;
                 }
                 if (shouldUpdate) break;
             }
 
             if (shouldUpdate) {
-                // Wait for DOM to be fully rendered
                 setTimeout(() => {
                     this.updateSlotFields();
                 }, 100);
             }
         });
 
-        // Observe the entire document for now
-        // We could optimize this by finding the specific slot_content container
-        observer.observe(document.body, {
+        observer.observe(observeTarget, {
             childList: true,
             subtree: true
         });
 
-        // Store observer reference for cleanup if needed
         this.observer = observer;
     }
 
@@ -111,23 +121,18 @@ class SlotChooserWidget {
             this.updateSlotFields();
         } catch (error) {
             console.error('Failed to fetch slots:', error);
-            // Fallback: allow manual input
             this.slots = [];
         }
     }
 
     updateSlotFields() {
-        // Find all slot_id fields within slot_content
-        let slotIdFields = document.querySelectorAll(
-            `input[name*="${this.slotContentFieldId}"][name*="slot_id"]`
+        // Search both input and select elements (converted fields become <select>)
+        const allFields = document.querySelectorAll(
+            'input[name$="-slot_id"], select[name$="-slot_id"]'
         );
-
-        // If not found, try alternative selector
-        if (slotIdFields.length === 0) {
-            slotIdFields = document.querySelectorAll(
-                `input[name^="${this.slotContentFieldId}"][name$="-slot_id"]`
-            );
-        }
+        const slotIdFields = Array.from(allFields).filter(
+            f => this.directSlotPattern.test(f.name)
+        );
 
         slotIdFields.forEach((field) => {
             this.convertToDropdown(field);
@@ -135,40 +140,33 @@ class SlotChooserWidget {
     }
 
     convertToDropdown(inputField) {
-        // If no slots detected, keep as text input
         if (this.slots.length === 0) {
             return;
         }
 
-        // Check if already converted
         if (inputField.dataset.slotChooserConverted === 'true') {
             this.updateDropdownOptions(inputField);
             return;
         }
 
-        // Save current value
         const currentValue = inputField.value;
 
-        // Create select element
         const select = document.createElement('select');
         select.name = inputField.name;
         select.id = inputField.id;
         select.className = inputField.className;
         select.dataset.slotChooserConverted = 'true';
 
-        // Add empty option
         const emptyOption = document.createElement('option');
         emptyOption.value = '';
         emptyOption.textContent = '-- Select a slot --';
         select.appendChild(emptyOption);
 
-        // Add slot options
         this.slots.forEach(slot => {
             const option = document.createElement('option');
             option.value = slot.id;
             option.textContent = slot.label;
 
-            // Mark slots with default content
             if (slot.has_default) {
                 option.textContent += ' (has default)';
             }
@@ -180,23 +178,19 @@ class SlotChooserWidget {
             select.appendChild(option);
         });
 
-        // Replace input with select
         inputField.parentNode.replaceChild(select, inputField);
     }
 
     updateDropdownOptions(selectField) {
         const currentValue = selectField.value;
 
-        // Clear existing options
         selectField.innerHTML = '';
 
-        // Add empty option
         const emptyOption = document.createElement('option');
         emptyOption.value = '';
         emptyOption.textContent = '-- Select a slot --';
         selectField.appendChild(emptyOption);
 
-        // Add new slot options
         this.slots.forEach(slot => {
             const option = document.createElement('option');
             option.value = slot.id;
@@ -210,7 +204,7 @@ class SlotChooserWidget {
                 option.selected = true;
             }
 
-            select.appendChild(option);
+            selectField.appendChild(option);
         });
     }
 }


### PR DESCRIPTION
## Summary
Closes #228

Fix three bugs in slot-chooser.js that cause nested ReusableLayoutBlock slot dropdowns to be overwritten by parent layout's slot choices.

## Changes
| Target | Change | History |
|--------|--------|---------|
| `slot-chooser.js` | Fix overly broad selector to match only direct slot_content children | TBD |
| `slot-chooser.js` | Scope MutationObserver to specific slot_content container | TBD |
| `slot-chooser.js` | Fix variable name bug in `updateDropdownOptions()` | TBD |

## Test Plan
| Scenario | Action | Expected Result |
|----------|--------|-----------------|
| TBD | TBD | TBD |